### PR TITLE
Add InflowvalidationConverter with count validation rule

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/MultistageProperties.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/MultistageProperties.java
@@ -497,6 +497,24 @@ public enum MultistageProperties {
    * path and fields, etc.
    */
   MSTAGE_PAYLOAD_PROPERTY("ms.payload.property", JsonArray.class),
+  /**
+   * This property is required for inflowValidation with simple count comparison rule
+   * The rule is accepted as a JsonObject with following Keys
+   * 1. "threshold" - represents the percentage of accepted failure records to mark job as passed
+   * 2. "criteria" - this value can be "fail" or "success" , fail represents that input record only has failed records
+   * 3. "errorColumn" - this value is optional and is required when we require to filter the failure records based on a specific column
+   * if the input record has only success records then set this as "success"
+   * Ex: ms.validation.attributes={"threshold": "10", "criteria" : "fail"}
+   */
+  MSTAGE_VALIDATION_ATTRIBUTES("ms.validation.attributes", JsonObject.class) {
+    @Override
+    public <T> T getDefaultValue() {
+      JsonObject attributesJson = new JsonObject();
+      attributesJson.addProperty(StaticConstants.KEY_WORD_THRESHOLD, 0);
+      attributesJson.addProperty(StaticConstants.KEY_WORD_CRITERIA, StaticConstants.KEY_WORD_FAIL);
+      return (T) attributesJson;
+    }
+  },
   MSTAGE_RETENTION("ms.retention", JsonObject.class) {
     @Override
     public <T> T getDefaultValue() {

--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
@@ -52,7 +52,10 @@ public interface StaticConstants {
   String KEY_WORD_UNITS = "units";
   String KEY_WORD_UNKNOWN = "unknown";
   String KEY_WORD_VALUES = "values";
-
+  String KEY_WORD_THRESHOLD = "threshold";
+  String KEY_WORD_CRITERIA = "criteria";
+  String KEY_WORD_FAIL = "fail";
+  String KEY_WORD_SUCCESS = "success";
+  String KEY_WORD_ERROR_COLUMN = "errorColumn";
   Gson GSON = new Gson();
-
 }

--- a/cdi-core/src/main/java/com/linkedin/cdi/converter/InFlowValidationConverter.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/converter/InFlowValidationConverter.java
@@ -1,0 +1,164 @@
+// Copyright 2021 LinkedIn Corporation. All rights reserved.
+// Licensed under the BSD-2 Clause license.
+// See LICENSE in the project root for license information.
+
+package com.linkedin.cdi.converter;
+
+import com.google.common.base.Optional;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.linkedin.cdi.configuration.MultistageProperties;
+import com.linkedin.cdi.configuration.StaticConstants;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.converter.Converter;
+import com.linkedin.cdi.util.HdfsReader;
+import org.apache.gobblin.util.AvroUtils;
+import org.apache.gobblin.util.EmptyIterable;
+
+import static com.linkedin.cdi.configuration.StaticConstants.*;
+
+
+/**
+ * This converter does basic count validation based on the Failure Records or Success Records criteria.
+ */
+@Slf4j
+public class InFlowValidationConverter extends Converter<Schema, Schema, GenericRecord, GenericRecord> {
+  int expectedRecordsCount;
+  int actualRecordsCount;
+  private String field;
+  private int failurePercentage;
+  private String criteria;
+  private String errorColumn;
+
+  @Override
+  public Converter<Schema, Schema, GenericRecord, GenericRecord> init(WorkUnitState workUnitState) {
+    //Load the input to memory
+    getPayloads(workUnitState);
+    fillValidationAttributes(workUnitState);
+    return super.init(workUnitState);
+  }
+
+  @Override
+  public Schema convertSchema(Schema inputSchema, WorkUnitState workUnit) {
+    return inputSchema;
+  }
+
+  @Override
+  public Iterable<GenericRecord> convertRecord(Schema outputSchema, GenericRecord inputRecord, WorkUnitState workUnit) {
+    Optional<Object> eof = AvroUtils.getFieldValue(inputRecord, KEY_WORD_EOF);
+    if (eof.isPresent() && eof.get().toString().equals(KEY_WORD_EOF)) {
+      validateRule();
+    } else {
+      verifyAndUpdateCount(inputRecord);
+    }
+    return new EmptyIterable<>();
+  }
+
+  private void verifyAndUpdateCount(GenericRecord inputRecord) {
+    List<Schema.Field> fieldList = inputRecord.getSchema().getFields();
+    if (fieldList.size() == 1 && inputRecord.get(fieldList.get(0).name()) instanceof GenericData.Array) {
+      // Check if error column exists and is not null
+      if (errorColumn != null) {
+        GenericData.Array<GenericRecord> arrayElements = (GenericData.Array) inputRecord.get(fieldList.get(0).name());
+        arrayElements.stream().iterator().forEachRemaining(this::updateFailureCount);
+      } else {
+        actualRecordsCount += ((GenericData.Array<?>) inputRecord.get(fieldList.get(0).name())).size();
+      }
+    } else {
+      if (errorColumn != null) {
+        updateFailureCount(inputRecord);
+      } else {
+        throw new RuntimeException("Invalid ms.data.field/ms.validation.attributes configuration. "
+            + "InputRecord should be of type Array or should have errorColumn");
+      }
+    }
+  }
+
+  private void fillValidationAttributes(WorkUnitState workUnitState) {
+    JsonObject validationAttributes =
+        MultistageProperties.MSTAGE_VALIDATION_ATTRIBUTES.getValidNonblankWithDefault(workUnitState);
+    if (validationAttributes.has(KEY_WORD_THRESHOLD)) {
+      failurePercentage = validationAttributes.get(KEY_WORD_THRESHOLD).getAsInt();
+    }
+    if (validationAttributes.has(KEY_WORD_CRITERIA)) {
+      criteria = validationAttributes.get(KEY_WORD_CRITERIA).getAsString();
+    }
+    if (validationAttributes.has(KEY_WORD_ERROR_COLUMN)) {
+      errorColumn = validationAttributes.get(KEY_WORD_ERROR_COLUMN).getAsString();
+    }
+  }
+
+  /**
+   * Extract records from secondary input and store the expected record count.
+   * If field is configured in the secondary input and field column
+   *  is of type array expected record count with array size
+   *  else use all the input records as expected size
+   */
+  private void getPayloads(WorkUnitState workUnitState) {
+    JsonArray payloads = MultistageProperties.MSTAGE_SECONDARY_INPUT.getValidNonblankWithDefault(workUnitState);
+    JsonArray records = new JsonArray();
+    List<String> fields = new ArrayList<>();
+    for (JsonElement entry : payloads) {
+      if (!entry.isJsonObject()) {
+        log.error("Elements within secondary input should be valid JsonObjects, provided: {}", entry.toString());
+      }
+      JsonObject entryJson = entry.getAsJsonObject();
+      records.addAll(new HdfsReader(workUnitState).readSecondary(entryJson));
+      if (entryJson.has(StaticConstants.KEY_WORD_FIELDS)) {
+        if (entryJson.get(StaticConstants.KEY_WORD_FIELDS).isJsonArray()) {
+          entryJson.get(StaticConstants.KEY_WORD_FIELDS)
+              .getAsJsonArray()
+              .forEach(arrayItem -> fields.add(arrayItem.getAsString()));
+        }
+        field = fields.size() >= 1 ? fields.get(0) : StringUtils.EMPTY;
+      }
+      // No of expected records
+      if (records.size() > 0 && StringUtils.isNotBlank(field) && (records.get(0)
+          .getAsJsonObject()
+          .get(field) instanceof JsonArray)) {
+        records.forEach(record -> expectedRecordsCount += record.getAsJsonObject().get(field).getAsJsonArray().size());
+      } else if (records.size() > 0) {
+        expectedRecordsCount = records.size();
+      }
+    }
+  }
+
+  private void updateFailureCount(GenericRecord record) {
+    if (record.get(errorColumn) != null) {
+      actualRecordsCount++;
+    }
+  }
+
+  /**
+   * Validate if failure/success percentage is within configured threshold
+   */
+  private void validateRule() {
+    // check the threshold and throw new Runtime Exception
+    float actualPercentage = ((float) actualRecordsCount / expectedRecordsCount) * 100;
+    boolean failJob = false;
+    // validate rules based on type of records
+    if (criteria.equalsIgnoreCase(KEY_WORD_FAIL)) {
+      failJob = actualPercentage > failurePercentage;
+    } else if (criteria.equalsIgnoreCase(KEY_WORD_SUCCESS)) {
+      failJob = (100 - actualPercentage) > failurePercentage;
+    }
+    log.info("Total expectedRecords: {} , failedRecords: {}", expectedRecordsCount, actualRecordsCount);
+
+    if (failJob) {
+      // Fail the validation by throwing runtime exception
+      throw new RuntimeException("Failure Threshold exceeds more than " + failurePercentage + "%");
+    } else {
+      log.info("Validation passed with failure rate {}% less than {}%",
+          new DecimalFormat("##.##").format(actualPercentage), failurePercentage);
+    }
+  }
+}


### PR DESCRIPTION
Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [JIRA](https://jira01.corp.linkedin.com:8443/issues) issues and references them in the PR title. 

### Description

InflowvalidationConverter with count validation rule. This implementation covers one validation, failure threshold count. 
The threshold can be mentioned as part of ms.validation.attributes parameter with 3 attributes threshold, criteria and errorColumn. Following are the 2 rules that can be configured
1. A threshold of 10 with criteria fail indiacates pass the validation as long as the failure count doesn't exceed 10% 
2. A threshold of 10 with criteria success indicates that max difference between success and overall count shouldn't exceed 10%


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

