### PR TITLE
Add text extractor for extracting unstructured output

### DIFF
--- a/cdi-core/src/test/java/com/linkedin/cdi/extractor/TextDumpJsonExtractor.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/extractor/TextDumpJsonExtractor.java
@@ -1,0 +1,194 @@
+package com.linkedin.cdi.extractor;
+
+// Copyright 2021 LinkedIn Corporation. All rights reserved.
+// Licensed under the BSD-2 Clause license.
+// See LICENSE in the project root for license information.
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.linkedin.cdi.configuration.StaticConstants;
+import com.linkedin.cdi.exception.RetriableAuthenticationException;
+import com.linkedin.cdi.keys.ExtractorKeys;
+import com.linkedin.cdi.keys.JobKeys;
+import com.linkedin.cdi.keys.JsonExtractorKeys;
+import com.linkedin.cdi.preprocessor.InputStreamProcessor;
+import com.linkedin.cdi.preprocessor.StreamProcessor;
+import com.linkedin.cdi.util.JsonUtils;
+import com.linkedin.cdi.util.WorkUnitStatus;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.testng.Assert;
+
+
+/**
+ * TextDumpJsonExtractor takes an InputStream, applies proper preprocessors, and returns a JSON output containing
+ * complete dump of output in output field.
+ * This will mainly be used in cases where output for any source is not in any specific format like Json/CSV/Avro
+ * Output Schema: [{"columnName":"output","isNullable":true,"dataType":{"type":"string"}}]
+ */
+@Slf4j
+public class TextDumpJsonExtractor extends JsonExtractor {
+
+  /* Keeping a limit of 10 MB so that it does not result in memory issues */
+  private final static int TEXT_EXTRACTOR_BYTE_LIMIT = 10 * 1024 * 1024;
+  private final static int BUFFER_SIZE = 8192;
+  private final static String TEXT_EXTRACTOR_SCHEMA =
+      "[{\"columnName\":\"output\",\"isNullable\":true,\"dataType\":{\"type\":\"string\"}}]";
+
+  public TextDumpJsonExtractor(WorkUnitState state, JobKeys jobKeys) {
+    super(state, jobKeys);
+  }
+
+  /**
+   * Returns a fixed schema from TEXT_EXTRACTOR_SCHEMA variable ain a JsonArray
+   *
+   * @return schema that is structured as a JsonArray but formatted as a String
+   */
+  @Override
+  public JsonArray getSchema() {
+    JsonParser parser = new JsonParser();
+    JsonElement jsonelement = parser.parse(TEXT_EXTRACTOR_SCHEMA);
+    JsonArray schemaArray = jsonelement.getAsJsonArray();
+    Assert.assertNotNull(schemaArray);
+    if (jobKeys.getDerivedFields().size() > 0 &&
+        JsonUtils.get(StaticConstants.KEY_WORD_COLUMN_NAME, jobKeys.getDerivedFields().keySet().iterator().next(),
+            StaticConstants.KEY_WORD_COLUMN_NAME, schemaArray) == JsonNull.INSTANCE) {
+      schemaArray.addAll(addDerivedFieldsToAltSchema());
+    }
+    log.debug("Schema Array is " + schemaArray);
+    return schemaArray;
+  }
+
+  @Nullable
+  @Override
+  public JsonObject readRecord(JsonObject reuse) {
+    log.warn("Here 2");
+    JsonExtractorKeys jsonExtractorKeys = super.getJsonExtractorKeys();
+    if (super.getJsonExtractorKeys().getTotalCount() >= 1) {
+      log.warn("Here 3");
+      return null;
+    }
+    if (processInputStream(jsonExtractorKeys.getTotalCount())) {
+      log.warn("Here 4");
+      jsonExtractorKeys.setTotalCount(1);
+      log.warn("Reading record for text extractor ");
+      StringBuffer output = new StringBuffer();
+      if (workUnitStatus.getBuffer() == null) {
+        log.warn("Received a NULL InputStream, ending the work unit ");
+        return null;
+      } else {
+        try {
+          // apply preprocessors
+          InputStream input = workUnitStatus.getBuffer();
+          for (StreamProcessor<?> transformer : extractorKeys.getPreprocessors()) {
+            if (transformer instanceof InputStreamProcessor) {
+              input = ((InputStreamProcessor) transformer).process(input);
+            }
+          }
+          writeToStringBuffer(input, output);
+          input.close();
+          JsonObject jsonObject = new JsonObject();
+          jsonObject.addProperty("output", output.toString());
+          JsonObject outputJson = addDerivedFields(jsonObject);
+          return outputJson;
+        } catch (Exception e) {
+          log.error("Error while extracting from source or writing to target", e);
+          this.state.setWorkingState(WorkUnitState.WorkingState.FAILED);
+          return null;
+        }
+      }
+    } else {
+      return this.readRecord(reuse);
+    }
+  }
+
+  /**
+   * write an input stream at the dump location.
+   */
+  private void writeToStringBuffer(InputStream is, StringBuffer output) {
+    Preconditions.checkNotNull(is, "InputStream");
+    try {
+      char[] buffer = new char[BUFFER_SIZE];
+      long totalBytes = 0;
+      int len = 0;
+      Reader in = new InputStreamReader(is, StandardCharsets.UTF_8);
+      while ((len = in.read(buffer)) != -1) {
+        output.append(String.valueOf(buffer));
+        totalBytes += len;
+        if (totalBytes > TEXT_EXTRACTOR_BYTE_LIMIT) {
+          log.warn("Download limit of {} bytes reached for text extractor ", TEXT_EXTRACTOR_BYTE_LIMIT);
+          break;
+        }
+      }
+      is.close();
+      log.info("TextExtractor: written {} bytes ", totalBytes);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to extract text in TextExtractor", e);
+    }
+  }
+
+  /**
+   * Core data extract function that calls the Source to obtain an InputStream and then
+   * decode the InputStream to records.
+   *
+   * @param starting the starting position of this extract, which mostly means the actual records
+   *                 that have been extracted previously
+   * @return false if no more data to be pulled or an significant error that requires early job termination
+   */
+  protected boolean processInputStream(long starting) {
+    holdExecutionUnitPresetStartTime();
+
+    if (isWorkUnitCompleted(starting)) {
+      return false;
+    }
+
+    currentParameters = isFirst(starting) ? getInitialWorkUnitParameters() : getCurrentWorkUnitParameters();
+    extractorKeys.setDynamicParameters(currentParameters);
+
+    WorkUnitStatus updatedStatus = null;
+    long retryies = Math.max(jobKeys.getRetryCount(), 1);
+    while (retryies > 0) {
+      try {
+        updatedStatus = connection == null ? null : isFirst(starting) ? connection.executeFirst(this.workUnitStatus)
+            : connection.executeNext(this.workUnitStatus);
+        retryies = 0;
+      } catch (RetriableAuthenticationException e) {
+        // TODO update sourceKeys
+        retryies--;
+      }
+    }
+
+    if (updatedStatus == null) {
+      this.failWorkUnit("Received a NULL WorkUnitStatus, fail the work unit");
+      return false;
+    }
+    // update work unit status
+    workUnitStatus.setBuffer(updatedStatus.getBuffer());
+    workUnitStatus.setMessages(updatedStatus.getMessages());
+    workUnitStatus.setSessionKey(getSessionKey(updatedStatus));
+
+    // update extractor key
+    extractorKeys.setSessionKeyValue(workUnitStatus.getSessionKey());
+
+    // read source schema from the message if available
+    if (jobKeys != null && !jobKeys.hasSourceSchema() && !jobKeys.hasOutputSchema() && workUnitStatus.getMessages()
+        .containsKey("schema")) {
+      jobKeys.setSourceSchema(workUnitStatus.getSchema());
+    }
+    return true;
+  }
+}

--- a/cdi-core/src/test/java/com/linkedin/cdi/extractor/TextExtractor.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/extractor/TextExtractor.java
@@ -1,0 +1,247 @@
+package com.linkedin.cdi.extractor;
+
+// Copyright 2021 LinkedIn Corporation. All rights reserved.
+// Licensed under the BSD-2 Clause license.
+// See LICENSE in the project root for license information.
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.linkedin.cdi.configuration.StaticConstants;
+import com.linkedin.cdi.keys.ExtractorKeys;
+import com.linkedin.cdi.keys.JobKeys;
+import com.linkedin.cdi.keys.JsonExtractorKeys;
+import com.linkedin.cdi.preprocessor.InputStreamProcessor;
+import com.linkedin.cdi.preprocessor.StreamProcessor;
+import com.linkedin.cdi.util.JsonUtils;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.testng.Assert;
+
+
+/**
+ * TextExtractor takes an InputStream, applies proper preprocessors, and returns a String output
+ */
+@Slf4j
+public class TextExtractor extends MultistageExtractor<JsonArray, JsonObject> {
+  private final static int TEXT_EXTRACTOR_BYTE_LIMIT = 1048576;
+  private final static int BUFFER_SIZE = 8192;
+  private final static String TEXT_EXTRACTOR_SCHEMA =
+      "[{\"columnName\":\"output\",\"isNullable\":true,\"dataType\":{\"type\":\"string\"}}]";
+  @Getter
+  private JsonExtractorKeys jsonExtractorKeys = new JsonExtractorKeys();
+
+  public TextExtractor(WorkUnitState state, JobKeys jobKeys) {
+    super(state, jobKeys);
+    super.initialize(this.getJsonExtractorKeys());
+    initialize(jsonExtractorKeys);
+  }
+
+  @Override
+  protected void initialize(ExtractorKeys keys) {
+    jsonExtractorKeys.logUsage(state);
+    jsonExtractorKeys.logDebugAll(state.getWorkunit());
+  }
+
+  /**
+   * Utility function to do a double assignment
+   * @param jsonExtractorKeys the extractor key
+   */
+  @VisibleForTesting
+  protected void setFileDumpExtractorKeys(JsonExtractorKeys jsonExtractorKeys) {
+    this.extractorKeys = jsonExtractorKeys;
+    this.jsonExtractorKeys = jsonExtractorKeys;
+  }
+
+  /**
+   * This method rely on the parent class to get a JsonArray formatted schema, and pass it out as
+   * a string. Typically we expect the downstream is a CsvToJsonConverter.
+   *
+   * @return schema that is structured as a JsonArray but formatted as a String
+   */
+  @Override
+  public JsonArray getSchema() {
+    JsonParser parser = new JsonParser();
+    JsonElement jsonelement = parser.parse(TEXT_EXTRACTOR_SCHEMA);
+    JsonArray schemaArray = jsonelement.getAsJsonArray();
+    Assert.assertNotNull(schemaArray);
+    if (jobKeys.getDerivedFields().size() > 0 &&
+        JsonUtils.get(StaticConstants.KEY_WORD_COLUMN_NAME, jobKeys.getDerivedFields().keySet().iterator().next(),
+            StaticConstants.KEY_WORD_COLUMN_NAME, schemaArray) == JsonNull.INSTANCE) {
+      schemaArray.addAll(addDerivedFieldsToAltSchema());
+    }
+    return schemaArray;
+  }
+
+  @Nullable
+  @Override
+  public JsonObject readRecord(JsonObject reuse) {
+    if (this.jsonExtractorKeys.getTotalCount() == 1) {
+      return null;
+    }
+    if (processInputStream(this.jsonExtractorKeys.getTotalCount())) {
+      this.jsonExtractorKeys.setTotalCount(1);
+      StringBuffer output = new StringBuffer();
+      if (workUnitStatus.getBuffer() == null) {
+        log.warn("Received a NULL InputStream, end the work unit");
+        return null;
+      } else {
+        try {
+          // apply preprocessors
+          InputStream input = workUnitStatus.getBuffer();
+          for (StreamProcessor<?> transformer : extractorKeys.getPreprocessors()) {
+            if (transformer instanceof InputStreamProcessor) {
+              input = ((InputStreamProcessor) transformer).process(input);
+            }
+          }
+          writeToStringBuffer(input, output);
+          input.close();
+          JsonObject jsonObject = new JsonObject();
+          jsonObject.addProperty("output", output.toString());
+          JsonObject outputJson = addDerivedFields(jsonObject);
+          return outputJson;
+        } catch (Exception e) {
+          log.error("Error while extracting from source or writing to target", e);
+          this.state.setWorkingState(WorkUnitState.WorkingState.FAILED);
+          return null;
+        }
+      }
+    } else {
+      return this.readRecord(reuse);
+    }
+  }
+
+  /**
+   * write an input stream at the dump location.
+   */
+  private void writeToStringBuffer(InputStream is, StringBuffer output) {
+    Preconditions.checkNotNull(is, "InputStream");
+    try {
+      char[] buffer = new char[BUFFER_SIZE];
+      long totalBytes = 0;
+      int len = 0;
+      Reader in = new InputStreamReader(is, StandardCharsets.UTF_8);
+      while ((len = in.read(buffer)) != -1) {
+        output.append(String.valueOf(buffer, 0, len));
+        totalBytes += len;
+        if (totalBytes > TEXT_EXTRACTOR_BYTE_LIMIT) {
+          log.warn("Download limit of {} bytes reached for text extractor ", TEXT_EXTRACTOR_BYTE_LIMIT);
+          break;
+        }
+      }
+      is.close();
+      log.info("TextExtractor: written {} bytes ", totalBytes);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to extract text in TextExtractor", e);
+    }
+  }
+  private String processDerivedFieldSource(JsonObject row, String name, Map<String, String> derivedFieldDef) {
+    String source = (String)derivedFieldDef.getOrDefault("source", "");
+    String inputValue = (String)derivedFieldDef.getOrDefault("value", "");
+    boolean isInputValueFromSource = false;
+    if (this.jsonExtractorKeys.getPushDowns().entrySet().size() > 0 && this.jsonExtractorKeys.getPushDowns().has(name)) {
+      inputValue = this.jsonExtractorKeys.getPushDowns().get(name).getAsString();
+      isInputValueFromSource = true;
+    } else if (this.isInputValueFromSource(source)) {
+      JsonElement ele = JsonUtils.get(row, source);
+      if (ele != null && !ele.isJsonNull()) {
+        inputValue = ele.getAsString();
+        isInputValueFromSource = true;
+      }
+    }
+
+    return this.generateDerivedFieldValue(name, derivedFieldDef, inputValue, isInputValueFromSource);
+  }
+
+  private JsonObject addDerivedFields(JsonObject row) {
+    Iterator var2 = this.jobKeys.getDerivedFields().entrySet().iterator();
+
+    while(var2.hasNext()) {
+      Map.Entry<String, Map<String, String>> derivedField = (Map.Entry)var2.next();
+      String name = (String)derivedField.getKey();
+      Map<String, String> derivedFieldDef = (Map)derivedField.getValue();
+      String strValue = this.processDerivedFieldSource(row, name, derivedFieldDef);
+      String type = (String)((Map)derivedField.getValue()).get("type");
+      byte var9 = -1;
+      switch(type.hashCode()) {
+        case -1034364087:
+          if (type.equals("number")) {
+            var9 = 5;
+          }
+          break;
+        case -934799095:
+          if (type.equals("regexp")) {
+            var9 = 2;
+          }
+          break;
+        case -891985903:
+          if (type.equals("string")) {
+            var9 = 1;
+          }
+          break;
+        case 3120063:
+          if (type.equals("epoc")) {
+            var9 = 0;
+          }
+          break;
+        case 64711720:
+          if (type.equals("boolean")) {
+            var9 = 3;
+          }
+          break;
+        case 1958052158:
+          if (type.equals("integer")) {
+            var9 = 4;
+          }
+      }
+
+      switch(var9) {
+        case 0:
+          if (strValue.length() > 0) {
+            row.addProperty(name, Long.parseLong(strValue));
+          }
+          break;
+        case 1:
+        case 2:
+          row.addProperty(name, strValue);
+          break;
+        case 3:
+          row.addProperty(name, Boolean.parseBoolean(strValue));
+          break;
+        case 4:
+          row.addProperty(name, Integer.parseInt(strValue));
+          break;
+        case 5:
+          row.addProperty(name, Double.parseDouble(strValue));
+          break;
+        default:
+          this.failWorkUnit("Unsupported type for derived fields: " + type);
+      }
+    }
+
+    return row;
+  }
+
+  /**
+   * Utility function to do a double assignment
+   * @param jsonExtractorKeys the extractor key
+   */
+  @VisibleForTesting
+  protected void setJsonExtractorKeys(JsonExtractorKeys jsonExtractorKeys) {
+    this.extractorKeys = jsonExtractorKeys;
+    this.jsonExtractorKeys = jsonExtractorKeys;
+  }
+}


### PR DESCRIPTION
Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [JIRA](https://github.com/linkedin/data-integration-library/issues/10) issues and references them in the PR title. 

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Currently DIL supports many structured format like CSV, Json, Avro and also many compression formats. Unstructured text format is supported only through FileDumpExtractor, which dumps output to HDFS. With FileDumpExtractor, output cannot be passed to any converter. Text Extractor should be supported, which can extract output in any format and pass it to some converter for further ETL rather than directly pushing this to HDFS. This is useful in cases where we want to get some URL output and then apply some custom parsing to get the required output.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test cases. 

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

