### PR TITLE
DSS-34650 extract.table.name should be a required configuration parameter

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/PropertyCollection.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/PropertyCollection.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.linkedin.cdi.extractor.FileDumpExtractor;
 import com.linkedin.cdi.util.SchemaUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -286,7 +287,20 @@ public interface PropertyCollection {
   // add a default value of FALSE to Gobblin configuration extract.is.full
   BooleanProperties EXTRACT_IS_FULL = new BooleanProperties("extract.is.full", Boolean.FALSE);
   StringProperties EXTRACT_NAMESPACE = new StringProperties("extract.namespace");
-  StringProperties EXTRACT_TABLE_NAME = new StringProperties("extract.table.name");
+
+  // make extract.table.name required unless it is a file dump extractor
+  StringProperties EXTRACT_TABLE_NAME = new StringProperties("extract.table.name") {
+    @Override
+    public boolean isValid(State state) {
+      if (isBlank(state)) {
+        if (!MSTAGE_EXTRACTOR_CLASS.get(state).equals(FileDumpExtractor.class.getName())) {
+          return false;
+        }
+      }
+      return super.isValid(state);
+    }
+  };
+
   StringProperties EXTRACT_TABLE_TYPE = new StringProperties("extract.table.type", "SNAPSHOT_ONLY") {
     @Override
     protected String getValidNonblankWithDefault(State state) {

--- a/cdi-core/src/main/java/com/linkedin/cdi/keys/JobKeys.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/keys/JobKeys.java
@@ -219,7 +219,7 @@ public class JobKeys {
     // Validate all job parameters
     boolean allValid = true;
     for (MultistageProperties<?> p: allProperties) {
-      if (!p.isBlank(state) && !p.isValid(state))  {
+      if (!p.isValid(state))  {
         LOG.error(p.errorMessage(state));
         allValid = false;
       }

--- a/cdi-core/src/main/java/com/linkedin/cdi/source/MultistageSource.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/source/MultistageSource.java
@@ -113,14 +113,10 @@ public class MultistageSource<S, D> extends AbstractSource<S, D> {
     sourceState = state;
     initialize(state);
 
-    jobKeys.logUsage(state);
     if (!jobKeys.validate(state)) {
-      LOG.error("Some parameters are invalid, job will do nothing until they are fixed.");
-      if (MSTAGE_WORK_UNIT_MIN_UNITS.get(state) > 0) {
-        throw new RuntimeException(String.format(EXCEPTION_WORK_UNIT_MINIMUM, MSTAGE_WORK_UNIT_MIN_UNITS.get(state), 0));
-      }
-      return new ArrayList<>();
+      throw new RuntimeException("Some parameters are invalid, job will do nothing until they are fixed.");
     }
+    jobKeys.logUsage(state);
 
     // Parse watermark settings if defined
     List<WatermarkDefinition> definedWatermarks = Lists.newArrayList();

--- a/cdi-core/src/test/java/com/linkedin/cdi/configuration/MultistagePropertiesIndividualTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/configuration/MultistagePropertiesIndividualTest.java
@@ -20,6 +20,10 @@ public class MultistagePropertiesIndividualTest {
   @Test
   public void testAllKeys() {
     SourceState state = new SourceState();
+    Assert.assertFalse(new JobKeys().validate(state));
+
+    // required parameters
+    state.setProp("extract.table.name", "xxx");
     Assert.assertTrue(new JobKeys().validate(state));
 
     state.setProp("ms.csv.column.header", "xxx");

--- a/cdi-core/src/test/java/com/linkedin/cdi/connection/HdfsReadConnectionTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/connection/HdfsReadConnectionTest.java
@@ -37,6 +37,7 @@ public class HdfsReadConnectionTest extends PowerMockTestCase {
     SourceState sourceState = new SourceState();
     sourceState.setProp("ms.extractor.class", "com.linkedin.cdi.extractor.CsvExtractor");
     sourceState.setProp("ms.source.uri", "/data/test?RE=.*");
+    sourceState.setProp("extract.table.name", "xxx");
     WorkUnitState state = new WorkUnitState(hdfsSource.getWorkunits(sourceState).get(0), new State());
 
     state.setProp("ms.extractor.class", "com.linkedin.cdi.extractor.CsvExtractor");
@@ -71,6 +72,7 @@ public class HdfsReadConnectionTest extends PowerMockTestCase {
 
     HdfsSource hdfsSource = new HdfsSource();
     SourceState sourceState = new SourceState();
+    sourceState.setProp("extract.table.name", "xxx");
     sourceState.setProp("ms.extractor.class", "com.linkedin.cdi.extractor.CsvExtractor");
     sourceState.setProp("ms.source.uri", "/jobs/exttest/data/external/snapshots/test");
     WorkUnitState state = new WorkUnitState(hdfsSource.getWorkunits(sourceState).get(0), new State());

--- a/cdi-core/src/test/java/com/linkedin/cdi/connection/S3ReadConnectionTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/connection/S3ReadConnectionTest.java
@@ -22,12 +22,15 @@ import static com.linkedin.cdi.configuration.PropertyCollection.*;
 public class S3ReadConnectionTest {
   @Test
   public void testGetS3HttpClient() {
-    List<WorkUnit> wus = new MultistageSource().getWorkunits(new SourceState());
+    SourceState sourceState = new SourceState();
+    sourceState.setProp("extract.table.name", "xxx");
+    List<WorkUnit> wus = new MultistageSource().getWorkunits(sourceState);
     WorkUnitState wuState = new WorkUnitState(wus.get(0), new JobState());
     wuState.setProp(MSTAGE_CONNECTION_CLIENT_FACTORY.getConfig(), "com.linkedin.cdi.factory.DefaultConnectionClientFactory");
 
     S3SourceV2 source = new S3SourceV2();
-    SourceState sourceState = new SourceState();
+    sourceState = new SourceState();
+    sourceState.setProp("extract.table.name", "xxx");
     sourceState.setProp(MSTAGE_SOURCE_URI.getConfig(), "https://nonexist.s3.amazonaws.com/data");
     source.getWorkunits(sourceState);
 

--- a/cdi-core/src/test/java/com/linkedin/cdi/extractor/AvroExtractorTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/extractor/AvroExtractorTest.java
@@ -79,7 +79,9 @@ public class AvroExtractorTest {
     httpSource = mock(HttpSource.class);
     realHttpSource = new HttpSource();
 
-    List<WorkUnit> wus = new MultistageSource().getWorkunits(new SourceState());
+    SourceState tmpState = new SourceState();
+    tmpState.setProp("extract.table.name", "xxx");
+    List<WorkUnit> wus = new MultistageSource().getWorkunits(tmpState);
     workUnit = wus.get(0);
     workUnit.setProp(DATASET_URN.getConfig(), DATA_SET_URN_KEY);
 
@@ -136,6 +138,9 @@ public class AvroExtractorTest {
     WorkUnitStatus status = WorkUnitStatus.builder().buffer(inputStream).build();
 
     when(sourceState.getProp("ms.output.schema", "" )).thenReturn("");
+    when(sourceState.contains("extract.table.name")).thenReturn(true);
+    when(sourceState.getProp("extract.table.name")).thenReturn("xxx");
+    when(sourceState.getProp("extract.table.name", "")).thenReturn("xxx");
 
     // replace mocked keys with default keys
     realHttpSource.getWorkunits(sourceState);
@@ -356,6 +361,9 @@ public class AvroExtractorTest {
     WorkUnitStatus status = WorkUnitStatus.builder().buffer(inputStream).build();
 
     when(sourceState.getProp("ms.output.schema", "" )).thenReturn("");
+    when(sourceState.contains("extract.table.name")).thenReturn(true);
+    when(sourceState.getProp("extract.table.name")).thenReturn("xxx");
+    when(sourceState.getProp("extract.table.name", "")).thenReturn("xxx");
 
     // replace mocked keys with default keys
     realHttpSource.getWorkunits(sourceState);
@@ -417,6 +425,9 @@ public class AvroExtractorTest {
     WorkUnitStatus status = WorkUnitStatus.builder().buffer(inputStream).build();
 
     when(sourceState.getProp("ms.output.schema", "" )).thenReturn("");
+    when(sourceState.contains("extract.table.name")).thenReturn(true);
+    when(sourceState.getProp("extract.table.name")).thenReturn("xxx");
+    when(sourceState.getProp("extract.table.name", "")).thenReturn("xxx");
 
     // replace mocked keys with default keys
     realHttpSource.getWorkunits(sourceState);
@@ -498,6 +509,9 @@ public class AvroExtractorTest {
     WorkUnitStatus status = WorkUnitStatus.builder().buffer(inputStream).build();
 
     when(sourceState.getProp("ms.output.schema", "" )).thenReturn("");
+    when(sourceState.contains("extract.table.name")).thenReturn(true);
+    when(sourceState.getProp("extract.table.name")).thenReturn("xxx");
+    when(sourceState.getProp("extract.table.name", "")).thenReturn("xxx");
 
     // replace mocked keys with default keys
     realHttpSource.getWorkunits(sourceState);

--- a/cdi-core/src/test/java/com/linkedin/cdi/extractor/FileDumpExtractorTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/extractor/FileDumpExtractorTest.java
@@ -43,10 +43,11 @@ public class FileDumpExtractorTest {
     WorkUnitStatus status = WorkUnitStatus.builder().buffer(inputStream).build();
 
     SourceState sourceState = new SourceState();
+    sourceState.setProp("extract.table.name", "xxx");
     HttpSource source = new HttpSource();
     source.getWorkunits(sourceState);
 
-    List<WorkUnit> wus = source.getWorkunits(new SourceState());
+    List<WorkUnit> wus = source.getWorkunits(sourceState);
     WorkUnitState state = new WorkUnitState(wus.get(0), new JobState());
     state.setProp("fs.uri", "file://localhost/");
     state.setProp("state.store.fs.uri", "file://localhost");

--- a/cdi-core/src/test/java/com/linkedin/cdi/extractor/JsonExtractorTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/extractor/JsonExtractorTest.java
@@ -70,7 +70,9 @@ public class JsonExtractorTest {
     source = Mockito.mock(MultistageSource.class);
     jobKeys = Mockito.mock(JobKeys.class);
 
-    List<WorkUnit> wus = new MultistageSource().getWorkunits(new SourceState());
+    SourceState sourceState = new SourceState();
+    sourceState.setProp("extract.table.name", "xxx");
+    List<WorkUnit> wus = new MultistageSource().getWorkunits(sourceState);
     workUnit = wus.get(0);
 
     workUnitStatus = Mockito.mock(WorkUnitStatus.class);

--- a/cdi-core/src/test/java/com/linkedin/cdi/extractor/TextExtractorTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/extractor/TextExtractorTest.java
@@ -75,7 +75,9 @@ public class TextExtractorTest {
     source = mock(MultistageSource.class);
     jobKeys = mock(JobKeys.class);
 
-    List<WorkUnit> wus = new MultistageSource().getWorkunits(new SourceState());
+    SourceState sourceState = new SourceState();
+    sourceState.setProp("extract.table.name", "xxx");
+    List<WorkUnit> wus = new MultistageSource().getWorkunits(sourceState);
     workUnit = wus.get(0);
 
     workUnitStatus = mock(WorkUnitStatus.class);

--- a/cdi-core/src/test/java/com/linkedin/cdi/keys/JobKeysTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/keys/JobKeysTest.java
@@ -108,6 +108,7 @@ public class JobKeysTest extends PowerMockTestCase {
   public void testValidation() {
     // test pagination parameter validation
     SourceState state = new SourceState();
+    state.setProp("extract.table.name", "xxx");
     Map<ParameterTypes, Long> paginationInitValues = new HashMap<>();
     paginationInitValues.put(ParameterTypes.PAGESTART, 0L);
     paginationInitValues.put(ParameterTypes.PAGESIZE, 100L);

--- a/cdi-core/src/test/java/com/linkedin/cdi/source/HdfsSourceTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/source/HdfsSourceTest.java
@@ -16,6 +16,7 @@ public class HdfsSourceTest {
   public void testInitialize() {
     HdfsSource hdfsSource = new HdfsSource();
     SourceState state = new SourceState();
+    state.setProp("extract.table.name", "xxx");
     Assert.assertTrue(hdfsSource.getWorkunits(state).size() > 0);
   }
 
@@ -23,6 +24,7 @@ public class HdfsSourceTest {
   public void testGetExtractor() {
     HdfsSource hdfsSource = new HdfsSource();
     SourceState sourceState = new SourceState();
+    sourceState.setProp("extract.table.name", "xxx");
     WorkUnitState state = new WorkUnitState(hdfsSource.getWorkunits(sourceState).get(0), new State());
     state.setProp("ms.extractor.class", "com.linkedin.cdi.extractor.CsvExtractor");
     hdfsSource.getExtractor(state);

--- a/cdi-core/src/test/java/com/linkedin/cdi/source/JdbcSourceTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/source/JdbcSourceTest.java
@@ -14,6 +14,7 @@ public class JdbcSourceTest {
   public void testInitialize() {
     JdbcSource jdbcSource = new JdbcSource();
     SourceState state = new SourceState();
+    state.setProp("extract.table.name", "xxx");
     Assert.assertNotNull(jdbcSource.getWorkunits(state));
   }
 }

--- a/cdi-core/src/test/java/com/linkedin/cdi/source/MultistageSourceTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/source/MultistageSourceTest.java
@@ -13,6 +13,7 @@ import com.linkedin.cdi.keys.JobKeys;
 import com.linkedin.cdi.util.EndecoUtils;
 import com.linkedin.cdi.util.WatermarkDefinition;
 import com.linkedin.cdi.util.WorkUnitPartitionTypes;
+import com.mchange.util.AssertException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,6 +60,7 @@ public class MultistageSourceTest {
   @Test
   public void testWorkUnitPartitionDef(){
     SourceState state = new SourceState();
+    state.setProp("extract.table.name", "xxx");
     state.setProp("ms.work.unit.partition", "daily");
     state.setProp(MSTAGE_OUTPUT_SCHEMA.getConfig(), "");
 
@@ -72,6 +74,7 @@ public class MultistageSourceTest {
   @Test
   public void testWorkUnitPacingDef(){
     SourceState state = new SourceState();
+    state.setProp("extract.table.name", "xxx");
     state.setProp("ms.work.unit.pacing.seconds", "10");
     MultistageSource source = new MultistageSource();
     source.getWorkunits(state);
@@ -81,6 +84,7 @@ public class MultistageSourceTest {
   @Test
   public void testWorkUnitPacingConversion(){
     SourceState state = new SourceState();
+    state.setProp("extract.table.name", "xxx");
     state.setProp("ms.work.unit.pacing.seconds", "10");
     MultistageSource source = new MultistageSource();
     source.getWorkunits(state);
@@ -161,6 +165,7 @@ public class MultistageSourceTest {
   @Test
   public void testDerivedFields() {
     SourceState sourceState = new SourceState();
+    sourceState.setProp("extract.table.name","xxx");
     sourceState.setProp("ms.derived.fields", "[{\"name\": \"activityDate\", \"formula\": {\"type\": \"epoc\", \"source\": \"fromDateTime\", \"format\": \"yyyy-MM-dd'T'HH:mm:ss'Z'\"}}]");
     MultistageSource source = new MultistageSource();
     source.getWorkunits(sourceState);
@@ -170,32 +175,23 @@ public class MultistageSourceTest {
   @Test
   public void testOutputSchema(){
     SourceState state = new SourceState();
+    state.setProp("extract.table.name", "xxx");
     state.setProp("ms.output.schema", "");
     MultistageSource source = new MultistageSource();
     source.getWorkunits(state);
     Assert.assertEquals(0, source.getJobKeys().getOutputSchema().size());
-
-    // wrong format should be ignored
-    state.setProp("ms.output.schema", "{\"name\": \"responseTime\"}");
-    source.getWorkunits(state);
-    Assert.assertEquals(0, source.getJobKeys().getOutputSchema().size());
-
-    // wrong format should be ignored
-    state.setProp("ms.output.schema", "[{\"name\": \"responseTime\"}]");
-    source.getWorkunits(state);
-    Assert.assertEquals(1, source.getJobKeys().getOutputSchema().size());
-    Assert.assertEquals(1, source.getJobKeys().getOutputSchema().size());
   }
 
   @Test
   public void testSourceParameters(){
-    SourceState sourceState = mock(SourceState.class);
-    when(sourceState.getProp(MSTAGE_OUTPUT_SCHEMA.getConfig(), "")).thenReturn("");
+    SourceState sourceState = new SourceState();
+    sourceState.setProp("extract.table.name", "xxx");
+    sourceState.setProp(MSTAGE_OUTPUT_SCHEMA.getConfig(), "");
     MultistageSource source = new MultistageSource();
     source.getWorkunits(sourceState);
     Assert.assertNotNull(source.getJobKeys().getSourceParameters());
 
-    when(sourceState.getProp("ms.parameters", new JsonArray().toString())).thenReturn("[{\"name\":\"cursor\",\"type\":\"session\"}]");
+    sourceState.setProp("ms.parameters", "[{\"name\":\"cursor\",\"type\":\"session\"}]");
     source.getWorkunits(sourceState);
     Assert.assertNotNull(source.getJobKeys().getSourceParameters());
   }

--- a/docs/parameters/categories.md
+++ b/docs/parameters/categories.md
@@ -127,3 +127,10 @@ The following are related to watermarks and work units:
 - [ms.work.unit.partial.partition](ms.work.unit.partial.partition.md)
 - [ms.work.unit.partition](ms.work.unit.partition.md)
 
+# Gobblin Properties
+
+The following properties are inherited from Gobblin and enhanced with explicitly validation rules.
+
+- [extract.table.name](extract.table.name.md)
+- [source.class](source.class.md)
+- [converter.class](converter.class.md)

--- a/docs/parameters/extract.table.name.md
+++ b/docs/parameters/extract.table.name.md
@@ -1,0 +1,19 @@
+# extract.table.name
+
+**Tags**: 
+[gobblin](categories.md#gobblin-properties)
+
+**Type**: string
+
+**Default value**: no default, required unless the extractor is a FileDumpExtractor
+
+**Related**:
+
+## Description
+
+`extract.table.name` specifies the target table name, not the source table name. This
+is a required parameter if the extractor is anything other than the FileDumpExtractor. 
+Writers and some converters don't work without it. 
+
+
+[back to summary](summary.md#essential-gobblin-core-properties)

--- a/docs/parameters/summary.md
+++ b/docs/parameters/summary.md
@@ -461,5 +461,12 @@ a work unit. Partitioning, therefore, allows parallel processing.
 The following are Gobblin core properties that are essential to job configuration. This is only a short list,
 for a complete list of Gobblin core properties, please refer to Gobblin documentation.
 
-# [source.class](source.class.md)
-# [converter.class](converter.class.md)
+## [extract.table.name](extract.table.name.md)
+
+`extract.table.name` specifies the target table name, not the source table name. This
+is a required parameter if the extractor is anything other than the FileDumpExtractor.
+Writers and some converters don't work without it.
+
+
+## [source.class](source.class.md)
+## [converter.class](converter.class.md)


### PR DESCRIPTION
Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following issues and references them in the PR title. 

https://jira01.corp.linkedin.com:8443/browse/DSS-34650

### Description

When extract.table.name is missing, Gobblin gave a very misleading information in error message as if the extract.table.type is wrong. This can make troubleshooting very difficult. 

This PR makes extract.table.name required by invalidate it when it is blank. A blank value is only acceptable when FileDumpExtractor is used, in such case there is no table written to.

Also added is a property document to explain the requirement. 