### PR TITLE
decoupling payload and authentication categories during workunit crea…

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/source/MultistageSource.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/source/MultistageSource.java
@@ -157,15 +157,14 @@ public class MultistageSource<S, D> extends AbstractSource<S, D> {
           jobKeys.getMinWorkUnits()));
     }
 
-    if (authentications != null && authentications.size() == 1) {
-      for (WorkUnit wu : wuList) {
+    for (WorkUnit wu : wuList) {
+      if (authentications != null && authentications.size() == 1) {
         wu.setProp(MSTAGE_ACTIVATION_PROPERTY.toString(),
             getUpdatedWorkUnitActivation(wu, authentications.get(0).getAsJsonObject()));
-
+      }
         // unlike activation secondary inputs, payloads will be processed in each work unit
         // and payloads will not be loaded until the Connection executes the command
         wu.setProp(MSTAGE_PAYLOAD_PROPERTY.toString(), payloads);
-      }
     }
     return wuList;
   }


### PR DESCRIPTION

Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### Description
- In the current set up, both authentication and payload categories are coupled during work unit creation, as a result for use cases where payload is required  in the secondary inputs but not authentication are failing. If Authentication is not defined in ms.secondary.input the payload parameter is also being ignored due to this check. Removed the authentication check into the loop to handle the issue


### Tests
- No changes to Unit tests. Existing tested passed during build