### PR TITLE
Allow variables in payload path and documentation change

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
@@ -81,6 +81,8 @@ public interface StaticConstants {
   String EXCEPTION_INCORRECT_CONFIGURATION = "Property %s has incorrect configuration: %s, see: %s";
   String EXCEPTION_DEPRECATED_CONFIGURATION = "Property %s has been deprecated, and the replacement is: %s, see: %s";
 
+  String ERROR_READING_SECONDARY_INPUT =  "Error reading %s secondary input for work unit %s";
+
   String MSG_ROWS_PROCESSED = "Processed %s records, work unit: %s";
   String MSG_WORK_UNIT_ALWAYS = "There should be a work unit.";
   String MSG_LOW_WATER_MARK_ALWAYS = "There should be a low watermark.";

--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/WatermarkProperties.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/WatermarkProperties.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonObject;
 import com.linkedin.cdi.util.DateTimeUtils;
 import com.linkedin.cdi.util.JsonUtils;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -139,7 +140,9 @@ public class WatermarkProperties extends JsonArrayProperties {
       }
       return unitList;
     } else if (units.isJsonPrimitive()) {
-      return Lists.newArrayList(units.getAsString().split(KEY_WORD_COMMA));
+      List<String> unitList = Lists.newArrayList();
+      Arrays.stream(units.getAsString().split(KEY_WORD_COMMA)).forEach(x -> unitList.add(x.trim()));
+      return unitList;
     }
     return null;
   }

--- a/cdi-core/src/main/java/com/linkedin/cdi/keys/JobKeys.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/keys/JobKeys.java
@@ -63,7 +63,6 @@ public class JobKeys {
 
   private JsonObject sessionKeyField = new JsonObject();
   private String totalCountField = StringUtils.EMPTY;
-  private JsonArray sourceParameters = new JsonArray();
   private Map<ParameterTypes, String> paginationFields = new HashMap<>();
   private Map<ParameterTypes, Long> paginationInitValues = new HashMap<>();
   private long sessionTimeout;
@@ -90,7 +89,6 @@ public class JobKeys {
     parsePaginationInitialValues(state);
     setSessionKeyField(MSTAGE_SESSION_KEY_FIELD.get(state));
     setTotalCountField(MSTAGE_TOTAL_COUNT_FIELD.get(state));
-    setSourceParameters(MSTAGE_PARAMETERS.get(state));
     setSourceUri(MSTAGE_SOURCE_URI.get(state));
     setDefaultFieldTypes(parseDefaultFieldTypes(state));
     setDerivedFields(parseDerivedFields(state));
@@ -576,14 +574,6 @@ public class JobKeys {
 
   public void setTotalCountField(String totalCountField) {
     this.totalCountField = totalCountField;
-  }
-
-  public JsonArray getSourceParameters() {
-    return sourceParameters;
-  }
-
-  public void setSourceParameters(JsonArray sourceParameters) {
-    this.sourceParameters = sourceParameters;
   }
 
   public Map<ParameterTypes, String> getPaginationFields() {

--- a/cdi-core/src/main/java/com/linkedin/cdi/util/WatermarkDefinition.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/util/WatermarkDefinition.java
@@ -164,7 +164,7 @@ public class WatermarkDefinition {
       List<String> units = Lists.newArrayList(commaSeparatedUnits.split(StringUtils.COMMA_STR));
       for (String unit: units) {
         JsonObject jsonObject = new JsonObject();
-        jsonObject.addProperty(name, unit);
+        jsonObject.addProperty(name, unit.trim());
         unitArray.add(jsonObject);
       }
       this.setUnits(unitArray.toString());

--- a/cdi-core/src/test/java/com/linkedin/cdi/configuration/SecondaryInputPropertiesTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/configuration/SecondaryInputPropertiesTest.java
@@ -1,0 +1,58 @@
+// Copyright 2021 LinkedIn Corporation. All rights reserved.
+// Licensed under the BSD-2 Clause license.
+// See LICENSE in the project root for license information.
+
+package com.linkedin.cdi.configuration;
+
+import com.google.gson.JsonArray;
+import com.linkedin.cdi.extractor.MultistageExtractor;
+import com.linkedin.cdi.keys.JobKeys;
+import com.linkedin.cdi.source.HdfsSource;
+import gobblin.runtime.JobState;
+import java.util.List;
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.linkedin.cdi.configuration.PropertyCollection.*;
+import static com.linkedin.cdi.configuration.StaticConstants.*;
+
+
+public class SecondaryInputPropertiesTest {
+  @Test
+  public void testVariableInPayloadPath() {
+    SourceState sourceState = new SourceState();
+    sourceState.setProp("extract.table.name", "xxx");
+    sourceState.setProp("ms.secondary.input", "[{\"path\": \"{{customerId}}\", \"fields\": [\"dummy\"], \"category\": \"payload\"}]");
+    sourceState.setProp("ms.source.uri", "/data/test?RE=.*");
+    sourceState.setProp("ms.watermark", "[{\"name\":\"customerId\",\"type\":\"unit\",\"units\":\"dir1, dir2, dir3\"}]");
+    sourceState.setProp(MSTAGE_CONNECTION_CLIENT_FACTORY.getConfig(),
+        "com.linkedin.cdi.factory.DefaultConnectionClientFactory");
+
+    Assert.assertTrue(new JobKeys().validate(sourceState));
+
+    HdfsSource source = new HdfsSource();
+    List<WorkUnit> wus = source.getWorkunits(sourceState);
+
+    // check 1st work unit
+    WorkUnitState wuState = new WorkUnitState(wus.get(0), new JobState());
+    wuState.setProp("ms.extractor.class", "com.linkedin.cdi.extractor.CsvExtractor");
+    MultistageExtractor extractor = (MultistageExtractor) source.getExtractor(wuState);
+    Assert.assertNotNull(extractor);
+    JsonArray payloads = extractor.getExtractorKeys().getPayloads();
+    Assert.assertEquals(payloads.size(), 1);
+    Assert.assertEquals(payloads.get(0).getAsJsonObject().get(KEY_WORD_PATH).getAsString(), "dir1");
+
+    // check 2nd work unit
+    wuState = new WorkUnitState(wus.get(1), new JobState());
+    wuState.setProp("ms.extractor.class", "com.linkedin.cdi.extractor.CsvExtractor");
+    extractor = (MultistageExtractor) source.getExtractor(wuState);
+    Assert.assertNotNull(extractor);
+    payloads = extractor.getExtractorKeys().getPayloads();
+    Assert.assertEquals(payloads.size(), 1);
+    Assert.assertEquals(payloads.get(0).getAsJsonObject().get(KEY_WORD_PATH).getAsString(), "dir2");
+
+  }
+}

--- a/cdi-core/src/test/java/com/linkedin/cdi/connection/MulstistageReadConnectionTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/connection/MulstistageReadConnectionTest.java
@@ -42,7 +42,6 @@ public class MulstistageReadConnectionTest extends PowerMockTestCase {
     JobKeys jobKeys = Mockito.mock(JobKeys.class);
     when(jobKeys.getCallInterval()).thenReturn(1L);
     conn.setJobKeys(jobKeys);
-    when(jobKeys.getSourceParameters()).thenReturn(new JsonArray());
     when(jobKeys.getCallInterval()).thenThrow(Mockito.mock(IllegalArgumentException.class));
     conn.executeNext(workUnitStatus);
     Assert.assertEquals(conn.executeNext(workUnitStatus), workUnitStatus);

--- a/cdi-core/src/test/java/com/linkedin/cdi/extractor/AvroExtractorTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/extractor/AvroExtractorTest.java
@@ -369,7 +369,6 @@ public class AvroExtractorTest {
     realHttpSource.getWorkunits(sourceState);
     avroExtractor.jobKeys = jobKeys;
     avroExtractor.setAvroExtractorKeys(new AvroExtractorKeys());
-    when(jobKeys.getSourceParameters()).thenReturn(realHttpSource.getJobKeys().getSourceParameters());
     when(jobKeys.getDataField()).thenReturn("results");
     when(multistageConnection.executeFirst(avroExtractor.workUnitStatus)).thenReturn(status);
 
@@ -433,7 +432,6 @@ public class AvroExtractorTest {
     realHttpSource.getWorkunits(sourceState);
     avroExtractor.jobKeys = jobKeys;
     avroExtractor.setAvroExtractorKeys(new AvroExtractorKeys());
-    when(jobKeys.getSourceParameters()).thenReturn(realHttpSource.getJobKeys().getSourceParameters());
     when(jobKeys.getDataField()).thenReturn("results");
     when(multistageConnection.executeFirst(avroExtractor.workUnitStatus)).thenReturn(status);
 
@@ -517,7 +515,6 @@ public class AvroExtractorTest {
     realHttpSource.getWorkunits(sourceState);
     avroExtractor.jobKeys = jobKeys;
     avroExtractor.setAvroExtractorKeys(new AvroExtractorKeys());
-    when(jobKeys.getSourceParameters()).thenReturn(realHttpSource.getJobKeys().getSourceParameters());
     when(jobKeys.getDataField()).thenReturn("results.0.wrapper.field1");
     when(multistageConnection.executeFirst(avroExtractor.workUnitStatus)).thenReturn(status);
 

--- a/cdi-core/src/test/java/com/linkedin/cdi/extractor/JsonExtractorTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/extractor/JsonExtractorTest.java
@@ -82,7 +82,6 @@ public class JsonExtractorTest {
     when(state.getWorkunit()).thenReturn(workUnit);
     workUnit.setProp(DATASET_URN.getConfig(), DATA_SET_URN_KEY);
     when(source.getJobKeys()).thenReturn(jobKeys);
-    when(jobKeys.getSourceParameters()).thenReturn(new JsonArray());
     when(jobKeys.getPaginationInitValues()).thenReturn(new HashMap<>());
     when(jobKeys.getSchemaCleansingPattern()).thenReturn("(\\s|\\$|@)");
     when(jobKeys.getSchemaCleansingReplacement()).thenReturn("_");

--- a/cdi-core/src/test/java/com/linkedin/cdi/extractor/TextExtractorTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/extractor/TextExtractorTest.java
@@ -4,48 +4,30 @@
 
 package com.linkedin.cdi.extractor;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.linkedin.cdi.configuration.MultistageProperties;
 import com.linkedin.cdi.connection.MultistageConnection;
 import com.linkedin.cdi.exception.RetriableAuthenticationException;
 import com.linkedin.cdi.keys.JobKeys;
 import com.linkedin.cdi.keys.JsonExtractorKeys;
-import com.linkedin.cdi.source.HttpSource;
 import com.linkedin.cdi.source.MultistageSource;
-import com.linkedin.cdi.util.JsonUtils;
-import com.linkedin.cdi.util.ParameterTypes;
-import com.linkedin.cdi.util.SchemaBuilder;
 import com.linkedin.cdi.util.WorkUnitStatus;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.configuration.WorkUnitState;
-import org.apache.gobblin.runtime.JobState;
 import org.apache.gobblin.source.workunit.WorkUnit;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
-import org.powermock.reflect.Whitebox;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import static com.linkedin.cdi.configuration.PropertyCollection.*;
 
-import static com.linkedin.cdi.configuration.MultistageProperties.*;
+import static com.linkedin.cdi.configuration.PropertyCollection.*;
 import static org.mockito.Mockito.*;
 
 
@@ -87,7 +69,6 @@ public class TextExtractorTest {
     when(state.getWorkunit()).thenReturn(workUnit);
     workUnit.setProp(DATASET_URN.getConfig(), DATA_SET_URN_KEY);
     when(source.getJobKeys()).thenReturn(jobKeys);
-    when(jobKeys.getSourceParameters()).thenReturn(new JsonArray());
     when(jobKeys.getPaginationInitValues()).thenReturn(new HashMap<>());
     when(jobKeys.getSchemaCleansingPattern()).thenReturn("(\\s|\\$|@)");
     when(jobKeys.getSchemaCleansingReplacement()).thenReturn("_");

--- a/cdi-core/src/test/java/com/linkedin/cdi/source/MultistageSourceTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/source/MultistageSourceTest.java
@@ -188,11 +188,8 @@ public class MultistageSourceTest {
     sourceState.setProp(MSTAGE_OUTPUT_SCHEMA.getConfig(), "");
     MultistageSource source = new MultistageSource();
     source.getWorkunits(sourceState);
-    Assert.assertNotNull(source.getJobKeys().getSourceParameters());
-
     sourceState.setProp("ms.parameters", "[{\"name\":\"cursor\",\"type\":\"session\"}]");
     source.getWorkunits(sourceState);
-    Assert.assertNotNull(source.getJobKeys().getSourceParameters());
   }
 
   @Test

--- a/docs/concepts/work-unit.md
+++ b/docs/concepts/work-unit.md
@@ -1,9 +1,15 @@
 # Work Unit
 
-"Time" watermarks can generate partitions, and "unit" watermarks have units. 
+A time partition and an activation unit make a work unit. DIL
+maintains execution states, including watermarks, for each work unit.
 
-Time watermark and unit watermark together creates work units, and DIL 
-maintains execution state including watermarks for each work unit. 
+A "time" watermark can generate partitions. Time partitions are defined by 
+[ms.watermark](../parameters/ms.watermark.md) and
+[ms.work.unit.partition](../parameters/ms.work.unit.partition.md).
+
+Activation units can have 2 sources: 
+- units of a unit watermark defined in [ms.watermark](../parameters/ms.watermark.md)
+- activation entries of a secondary input from [ms.secondary.input](../parameters/ms.secondary.input.md)
 
 Partitions and Units make a matrix. Assuming we have m periods and n units, 
 the matrix will be n x m. **Each combination of partitions and units makes 

--- a/docs/parameters/ms.secondary.input.md
+++ b/docs/parameters/ms.secondary.input.md
@@ -70,18 +70,26 @@ work units, i.e, all work units get the same authentication credentials/tokens.
 
 ### Payload Secondary Input
 
-`payload` secondary inputs are used to specify raw payload locations.
+`payload` secondary inputs are used to specify raw payload locations. 
+Payloads are read and passed to connections without processing. The connection will decide what to do about it. 
 
-Payloads are simply passed to connections without processing. The connection will decide 
-what to do about it. 
-For example, HTTP connection will read the records from the payload, and attach 1
-row to 1 HTTP request. If there are multiple rows, HTTP connection will page (see [pagination](https://github.com/linkedin/data-integration-library/blob/master/docs/concepts/pagination.md))
+For example, HTTP connection will attach 1 row to 1 HTTP request. If there are multiple rows, HTTP connection will page (see [pagination](https://github.com/linkedin/data-integration-library/blob/master/docs/concepts/pagination.md))
 through them. Therefore, each row of the payload is processed by 1 HTTP request. 
 
 `payload` secondary input is typically used in the egression flows. If there are many
-rows to send out, they can be "batched" so that the payload file has fewer number of
-records. 
- 
+rows to send out, they can be "batched" so that the payload file has fewer number of records. 
+
+The `path` of payload can have dynamic variables that came from either `ms.watermark`, `ms.parameters`, or activation type secondary
+input from `ms.secondary.input` itself. For example, the following configuration used the variable "customId" that
+is defined in `ms.watermark`. In execution, there will be 3 work units generated, each processing the payload under "/data/customer1",
+"/data/customer2", and "/data/customer3". 
+
+- `ms.secondary.input=[{"path": "/data/{{customerId}}", "fields": ["dummy"], "category": "payload"}]`
+- `ms.watermark=[{"name":"customerId","type":"unit","units":"customer1, customer2, customer3"}]`
+
+The variable can only be a job-level variables or a work-unit-level static variable.
+The variable cannot be a work-unit-level dynamic variables, like a pagination variable or a session variable.
+
 ### Examples
 
 In the following, we have a file with a list of ids and their statuses. We


### PR DESCRIPTION
This change to add variable support to payload type secondary input. The syntax is like the following:

`ms.secondary.input=[{"path": "/data/{{customerId}}", "fields": ["dummy"], "category": "payload"}]`

The variable could be other secondary "activation" entries, or variables defined in ms.parameters, or unit watermark that are defined in ms.watermark. 

The variable can only be job level variables or work unit level static variables. 
The variable cannot be work unit level dynamic variables, like pagination variables or session variables. 

Some other fixes are:
- allow whitespaces between values in a "unit" watermark
- removed getter and setter of payloadIterator
- removed sourceParameters from the jobKey as that is just a simple cache of ms.parameters. 