### PR TITLE
Add retry to SFTP ls command to fix the timeout issue

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/connection/SftpConnection.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/connection/SftpConnection.java
@@ -141,7 +141,7 @@ public class SftpConnection extends MultistageConnection {
     List<String> files = new ArrayList<>();
     LOG.info("Files to be processed from input " + filesPattern);
     try {
-      files = fsClient.ls(filesPattern);
+      files = fsClient.ls(filesPattern, 2);
       int i = 0;
       for (String file : files) {
         URI uri = new URI(file);
@@ -154,7 +154,8 @@ public class SftpConnection extends MultistageConnection {
         i++;
       }
     } catch (Exception e) {
-      LOG.error("Unable to list files " + e.getMessage());
+      LOG.error("Unable to list files after 2 tries. {}", e.getMessage());
+      throw new RuntimeException(e);
     }
     return files;
   }

--- a/cdi-core/src/main/java/com/linkedin/cdi/factory/sftp/SftpClient.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/factory/sftp/SftpClient.java
@@ -39,6 +39,14 @@ public interface SftpClient {
   List<String> ls(String path);
 
   /**
+   * Execute an FTP ls command with retries
+   * @param path path on target host to be listed
+   * @return the list of files and directories
+   */
+  List<String> ls(String path, final int retries);
+
+
+  /**
    * Get file modification time
    * @param path file path on target to be checked
    * @return the modification time in long format


### PR DESCRIPTION
In the 2-step file download with data trigger, the triggering step might wait for the files for long time, and the SFTP session will eventually timeout. And that will cause the ls command failure after a few moments. 

In this change, the session is reset when ls command fails, and the ls command is retried. Currently I think I retry in each status check cycle should be sufficient. We can make the connection retry a parameter in the future as I wanted to reuse the retry parameter designed for authentication. 