### PR TITLE
Raise exception when error processing the input stream in JSON extractor

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/JsonExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/JsonExtractor.java
@@ -225,7 +225,7 @@ public class JsonExtractor extends MultistageExtractor<JsonArray, JsonObject> {
     } catch (Exception e) {
       LOG.error("Source Error: {}", e.getMessage());
       state.setWorkingState(WorkUnitState.WorkingState.FAILED);
-      return false;
+      throw new RuntimeException(e);
     }
 
     LOG.debug("Checking parsed Json object");

--- a/cdi-core/src/main/java/com/linkedin/cdi/keys/HttpKeys.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/keys/HttpKeys.java
@@ -29,7 +29,6 @@ public class HttpKeys extends JobKeys {
 
   @Override
   public void logDebugAll() {
-    super.logDebugAll();
     LOG.debug("These are values in HttpSource");
     LOG.debug("Http Request Headers: {}", httpRequestHeaders);
     //LOG.debug("Http Request Headers with Authentication: {}", httpRequestHeadersWithAuthentication.toString());

--- a/cdi-core/src/main/java/com/linkedin/cdi/keys/JdbcKeys.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/keys/JdbcKeys.java
@@ -24,7 +24,6 @@ public class JdbcKeys extends JobKeys {
 
   @Override
   public void logDebugAll() {
-    super.logDebugAll();
     LOG.debug("These are values in JdbcSource");
     LOG.debug("JDBC statement: {}", jdbcStatement);
     LOG.debug("Initial values of dynamic parameters: {}", initialParameterValues);

--- a/cdi-core/src/main/java/com/linkedin/cdi/keys/S3Keys.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/keys/S3Keys.java
@@ -23,7 +23,6 @@ public class S3Keys extends JobKeys {
 
   @Override
   public void logDebugAll() {
-    super.logDebugAll();
     LOG.debug("These are values in S3SourceV2:");
     LOG.debug("S3 Bucket: {}", bucket);
     LOG.debug("S3 endpoint: {}", endpoint);

--- a/cdi-core/src/main/java/com/linkedin/cdi/keys/SftpKeys.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/keys/SftpKeys.java
@@ -18,7 +18,6 @@ public class SftpKeys extends JobKeys {
 
   @Override
   public void logDebugAll() {
-    super.logDebugAll();
     LOG.debug("These are values in SftpSource:");
     LOG.debug("sftp source path: {}", filesPath);
     LOG.debug("path separator: {}", pathSeparator);


### PR DESCRIPTION
InputStream exception was previously superseded; such exceptions only stops the ingestion and cause an error message being logged. The benefit of that the job flow can continue and we can get complete metrics reporting. Throwing an exception, however, is more appropriate as JSON will come in as whole or none. 