### PR TITLE
Add support for dynamically formatted ISO datetime data in derived fi…

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
@@ -16,6 +16,7 @@ public interface StaticConstants {
   String KEY_WORD_CATEGORY = "category";
   String KEY_WORD_COLUMN_NAME = "columnName";
   String KEY_WORD_COMMA = ",";
+  String KEY_WORD_CUSTOM = "custom";
   String KEY_WORD_DATA_IS_NULLABLE = "isNullable";
   String KEY_WORD_DATA_TYPE = "dataType";
   String KEY_WORD_DATA_TYPE_TYPE = "dataType.type";
@@ -29,6 +30,7 @@ public interface StaticConstants {
   String KEY_WORD_HEADER = "header";
   String KEY_WORD_HTTP_OK = "ok";
   String KEY_WORD_INTEGER = "integer";
+  String KEY_WORD_ISO = "ISO";
   String KEY_WORD_IS_NULLABLE = "isNullable";
   String KEY_WORD_ITEMS = "items";
   String KEY_WORD_MAP = "map";

--- a/cdi-core/src/main/java/com/linkedin/cdi/util/DateTimeUtils.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/util/DateTimeUtils.java
@@ -12,6 +12,8 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
+import static com.linkedin.cdi.configuration.StaticConstants.*;
+
 
 /**
  * a general datetime parsing utility
@@ -23,7 +25,6 @@ import org.joda.time.format.DateTimeFormatter;
  */
 
 public interface DateTimeUtils {
-  String DEFAULT_TIMEZONE = "America/Los_Angeles";
   DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd");
   Map<String, DateTimeFormatter> FORMATS = new ImmutableMap.Builder<String, DateTimeFormatter>()
       .put("\\d{4}-\\d{2}-\\d{2}", DateTimeFormat.forPattern("yyyy-MM-dd"))
@@ -83,7 +84,7 @@ public interface DateTimeUtils {
       .build();
 
   static DateTime parse(String dtString) {
-    return parse(dtString, DEFAULT_TIMEZONE);
+    return parse(dtString, TZ_LOS_ANGELES);
   }
 
   /**
@@ -95,7 +96,7 @@ public interface DateTimeUtils {
    * @return the parsed Date Time object
    */
   static DateTime parse(String dtString, String timezone) {
-    DateTimeZone timeZone = DateTimeZone.forID(timezone.isEmpty() ? DEFAULT_TIMEZONE : timezone);
+    DateTimeZone timeZone = DateTimeZone.forID(timezone.isEmpty() ? TZ_LOS_ANGELES : timezone);
     try {
       for (String format : FORMATS.keySet()) {
         if (dtString.matches(format)) {
@@ -146,7 +147,7 @@ public interface DateTimeUtils {
    */
   static DateTime parse(String dtString, String dtFormat, String tzString) {
     try {
-      DateTimeZone datetimeZone = DateTimeZone.forID(StringUtils.isBlank(tzString) ? DEFAULT_TIMEZONE : tzString);
+      DateTimeZone datetimeZone = DateTimeZone.forID(StringUtils.isBlank(tzString) ? TZ_LOS_ANGELES : tzString);
       DateTimeFormatter datetimeFormatter = DateTimeFormat.forPattern(dtFormat).withZone(datetimeZone);
       return datetimeFormatter.parseDateTime(
           dtString.length() > dtFormat.length() ? dtString.substring(0, dtFormat.length()) : dtString);

--- a/cdi-core/src/test/java/com/linkedin/cdi/util/WatermarkDefinitionTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/util/WatermarkDefinitionTest.java
@@ -11,7 +11,7 @@ import org.joda.time.DateTimeZone;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static com.linkedin.cdi.util.DateTimeUtils.*;
+import static com.linkedin.cdi.configuration.StaticConstants.*;
 
 
 @Test
@@ -208,7 +208,7 @@ public class WatermarkDefinitionTest {
     Assert.assertEquals(definitions.getDateTime("2020-01-01 10:00:30").toString(),
         "2020-01-01T10:00:30.000-08:00");
 
-    definitions.setTimezone(DEFAULT_TIMEZONE);
+    definitions.setTimezone(TZ_LOS_ANGELES);
     Assert.assertEquals(definitions.getDateTime("2020-01-01 10:00:30").toString(),
         "2020-01-01T10:00:30.000-08:00");
   }

--- a/docs/parameters/ms.derived.fields.md
+++ b/docs/parameters/ms.derived.fields.md
@@ -46,9 +46,18 @@ DIL supports 3 sources of derivation:
   - `PXD` is calculated in America/Los_Angeles timezone if no timezone is specified
   
 When the type is `epoc`, a format is required to specify how to convert the source to the desired epoch value, and 
-a `timezone` can optionally specified. If no format is specified, the source must be a long value, which represents
-a timestamp in milli-seconds. `timezone` can take values like `UTC`, `America/Los_Angeles`, `GMT` etc. Timezone values
-are case-sensitive. 
+a `timezone` can optionally specified. 
+
+- If no format is specified, the source must be a long value string, which represents a timestamp in milli-seconds. 
+- If there is a format specified, and it is not "iso" (case-insensitive), try the specified format first. In this case, the timezone is also required.
+  Without timezone America/Los_Angeles is assumed. Actual data is also cut to length of the format string if it is longer than the format.
+- If format is "iso" (case-insensitive), or the specified format doesn't match the actual data, it will try the following steps:
+  - try conversion using the standard ISO datetime format without timezone offset, assuming data itself has no timezone offset in it; 
+    The input timezone is used if provided, otherwise America/Los_Angeles is used.
+  - try conversion using the standard ISO date time format with timezone offset, assuming data itself has timezone offset in it; 
+    The input timezone is ignored even if it is provided.
+  
+When `timezone` is specified, it can take values like `UTC`, `America/Los_Angeles`, `GMT` etc. Timezone values are case-sensitive. 
 
 ### Example 1: the following defines a derived field using regular expression to subtract part of a source field </p>
 `[{
@@ -67,6 +76,7 @@ are case-sensitive.
     "type": "epoc",
     "source": "started",
     "format": "yyyy-MM-dd"
+    "timezone": "UTC"
   }
 }]`
 
@@ -94,5 +104,17 @@ Then the derived field can be defined as:
 ### Example 5: the following defines an epoc timestamp field based on flow execution time </p>
 `[{"name": "extractedDate", "formula": {"type": "epoc", "source": "CURRENTDATE"}}]`
 
+### Example 6: the following defines an epoc timestamp field from a field of dynamic format </p>
+
+When each row has differently formatted datetime values, and the values are one of ISO date time formats:
+
+`[{
+  "name": "start",
+  "formula": {
+    "type": "epoc",
+    "source": "started",
+    "format": "iso"
+  }
+}]`
 
 [back to summary](summary.md#msderivedfields)


### PR DESCRIPTION
To derive an Epoch, the source field can be a long string or a date time string. 

- When it is long value string, no format is needed. 
- When it is a date time string, format can be ISO or any valid Java date time format. 
    - when the format is "iso", the conversion will consider a list of possible ISO standard date time formats
    - when the format is other than "iso", the conversion will use the specified format unless the format doesn't match the actual data.    