### PR TITLE
Add timezone and explicit rounding to watermark

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
@@ -83,6 +83,10 @@ public interface StaticConstants {
 
   String PROPERTY_DELIMINATOR = ".";
   String REGEXP_DEFAULT_PATTERN = ".*";
+  String REGEXP_TIME_DURATION_PATTERN = "P\\d+D(T\\d+H)?(\\d+M)?(\\..*)?";
+  String REGEXP_DAY_ONLY_DURATION_PATTERN = "P\\d+D(\\..*)?";
+  String REGEXP_HOUR_ONLY_DURATION_PATTERN = "P\\d+D(T\\d+H)(\\..*)?";
+
   String DOC_BASE_URL = "https://github.com/linkedin/data-integration-library/blob/master/docs";
 
   String EXCEPTION_WORK_UNIT_MINIMUM = "Job requires a minimum of %s work unit(s) to proceed because ms.work.unit.min.units = %s.";

--- a/cdi-core/src/main/java/com/linkedin/cdi/source/MultistageSource.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/source/MultistageSource.java
@@ -75,7 +75,6 @@ public class MultistageSource<S, D> extends AbstractSource<S, D> {
   final static private String CURRENT_DATE_SYMBOL = "-";
   final static private String ACTIVATION_WATERMARK_NAME = "activation";
   // Avoid too many partition created from misconfiguration, Months * Days * Hours
-  final private static int MAX_DATETIME_PARTITION = 3 * 30 * 24;
 
   protected SourceState sourceState = null;
   JobKeys jobKeys = new JobKeys();
@@ -361,12 +360,6 @@ public class MultistageSource<S, D> extends AbstractSource<S, D> {
           MSTAGE_WORK_UNIT_PARTIAL_PARTITION.get(sourceState));
     } else {
       partitions.add(new ImmutablePair<>(datetimeRange.getLeft().getMillis(), datetimeRange.getRight().getMillis()));
-    }
-    // Safety check if too many partitions created
-    if (partitions.size() > MAX_DATETIME_PARTITION) {
-      // Preserve the last N partitions
-      partitions = partitions.subList(partitions.size() - MAX_DATETIME_PARTITION, partitions.size());
-      LOG.warn("Too many partitions, created {}, only processing the last {}", partitions.size(), MAX_DATETIME_PARTITION);
     }
     return partitions;
   }

--- a/cdi-core/src/test/java/com/linkedin/cdi/configuration/MultistagePropertiesIndividualTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/configuration/MultistagePropertiesIndividualTest.java
@@ -220,12 +220,12 @@ public class MultistagePropertiesIndividualTest {
     // normal datetime watermark
     state.setProp("ms.watermark", "[{\"name\": \"system\",\"type\": \"datetime\",\"range\": {\"from\": \"2019-01-01\", \"to\": \"-\"}}]");
     Assert.assertTrue(MSTAGE_WATERMARK.isValid(state));
-    Assert.assertEquals(MSTAGE_WATERMARK.getRanges(state).getRight(), "-");
+    Assert.assertEquals(MSTAGE_WATERMARK.getRange(state).getRight(), "-");
 
     // normal datetime watermark and normal unit watermark
     state.setProp("ms.watermark", "[{\"name\": \"system\",\"type\": \"datetime\", \"range\": {\"from\": \"2021-08-21\", \"to\": \"-\"}}, {\"name\": \"bucketId\", \"type\": \"unit\", \"units\": \"null,0,1,2,3,4,5,6,7,8,9\"}]");
     Assert.assertTrue(MSTAGE_WATERMARK.isValid(state));
-    Assert.assertEquals(MSTAGE_WATERMARK.getRanges(state).getLeft(), "2021-08-21");
+    Assert.assertEquals(MSTAGE_WATERMARK.getRange(state).getLeft(), "2021-08-21");
     Assert.assertEquals(MSTAGE_WATERMARK.getUnits(state), Lists.newArrayList("null,0,1,2,3,4,5,6,7,8,9".split(",")));
 
     state.setProp("ms.watermark", "[{\"name\": \"system\",\"type\": \"datetime\", \"range\": {\"from\": \"2020-01-01\", \"to\": \"2020-01-31\"}}]");
@@ -244,6 +244,26 @@ public class MultistagePropertiesIndividualTest {
     // YYYYMMDD format is not supported for now
     state.setProp("ms.watermark", "[{\"name\": \"system\",\"type\": \"datetime\", \"range\": {\"from\": \"20091201\", \"to\": \"-\"}}]");
     Assert.assertFalse(MSTAGE_WATERMARK.isValid(state));
+
+    // P0D is valid
+    state.setProp("ms.watermark", "[{\"name\": \"system\",\"type\": \"datetime\", \"range\": {\"from\": \"P0D\", \"to\": \"P0D\"}}]");
+    Assert.assertTrue(MSTAGE_WATERMARK.isValid(state));
+
+    // P0DT0H is valid
+    state.setProp("ms.watermark", "[{\"name\": \"system\",\"type\": \"datetime\", \"range\": {\"from\": \"P0DT0H\", \"to\": \"P0DT0H\"}}]");
+    Assert.assertTrue(MSTAGE_WATERMARK.isValid(state));
+
+    // P0DT0H0M is valid
+    state.setProp("ms.watermark", "[{\"name\": \"system\",\"type\": \"datetime\", \"range\": {\"from\": \"P0DT0H0M\", \"to\": \"P0DT0H0M\"}}]");
+    Assert.assertTrue(MSTAGE_WATERMARK.isValid(state));
+
+    // P0DT0H0M.UTC is valid
+    state.setProp("ms.watermark", "[{\"name\": \"system\",\"type\": \"datetime\", \"range\": {\"from\": \"P0DT0H0M.UTC\", \"to\": \"P0DT0H0M.UTC\"}}]");
+    Assert.assertTrue(MSTAGE_WATERMARK.isValid(state));
+
+    // P0DT0H0M.America/Los_Angeles is valid
+    state.setProp("ms.watermark", "[{\"name\": \"system\",\"type\": \"datetime\", \"range\": {\"from\": \"P0DT0H0M.America/Los_Angeles\", \"to\": \"P0DT0H0M.America/Los_Angeles\"}}]");
+    Assert.assertTrue(MSTAGE_WATERMARK.isValid(state));
   }
 
   @Test

--- a/cdi-core/src/test/java/com/linkedin/cdi/source/MultistageSourceTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/source/MultistageSourceTest.java
@@ -90,22 +90,6 @@ public class MultistageSourceTest {
     Assert.assertEquals(MSTAGE_WORK_UNIT_PACING_SECONDS.getMillis(state).longValue(), 10000L);
   }
 
-  @Test
-  public void testGetWorkUnitsTooManyPartitions() {
-    SourceState state = new SourceState();
-    state.setProp("ms.watermark",
-        "[{\"name\": \"system\",\"type\": \"datetime\", \"range\": {\"from\": \"2000-01-01\", \"to\": \"-\"}}]");
-    state.setProp("extract.table.type", "SNAPSHOT_ONLY");
-    state.setProp("extract.namespace", "test");
-    state.setProp("extract.table.name", "table1");
-    state.setProp("ms.work.unit.partition", "hourly");
-    state.setProp("ms.pagination", "{}");
-    MultistageSource source = new MultistageSource();
-    List<WorkUnit> wuList = source.getWorkunits(state);
-    // Expected max partition allowed maps to MultistageSource.MAX_DATETIME_PARTITION
-    Assert.assertEquals(wuList.size(), 3 * 30 * 24);
-  }
-
   @Test (expectedExceptions = RuntimeException.class)
   public void testGetWorkUnitsMinimumUnits() {
     SourceState state = new SourceState();

--- a/cdi-core/src/test/java/com/linkedin/cdi/util/WatermarkDefinitionTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/util/WatermarkDefinitionTest.java
@@ -51,14 +51,15 @@ public class WatermarkDefinitionTest {
     String expectedInDateTime = String.format("(%s,%s)",
         "2020-04-02T00:00:00.000-07:00",
         DateTime.now().withZone(timeZone).dayOfMonth().roundFloorCopy());
-    String jsonDef = "[{\"name\":\"system\",\"type\":\"datetime\",\"range\":{\"from\":\"2020-04-02\",\"to\":\"-\"}}]";
-    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef, false, WorkUnitPartitionTypes.WEEKLY,
+    String jsonDef1 = "[{\"name\":\"system\",\"type\":\"datetime\",\"range\":{\"from\":\"2020-04-02\",\"to\":\"-\"}}]";
+    String jsonDef2 = "[{\"name\":\"system\",\"type\":\"datetime\",\"range\":{\"from\":\"2020-04-02\",\"to\":\"P0D\"}}]";
+    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef2, false, WorkUnitPartitionTypes.WEEKLY,
         expectedInMillis, expectedInDateTime);
-    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef, true, WorkUnitPartitionTypes.WEEKLY,
+    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef2, true, WorkUnitPartitionTypes.WEEKLY,
         expectedInMillis, expectedInDateTime);
-    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef, false, WorkUnitPartitionTypes.MONTHLY,
+    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef2, false, WorkUnitPartitionTypes.MONTHLY,
         expectedInMillis, expectedInDateTime);
-    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef, true, WorkUnitPartitionTypes.MONTHLY,
+    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef2, true, WorkUnitPartitionTypes.MONTHLY,
         expectedInMillis, expectedInDateTime);
 
     // Testing with 'to' as 'two days ago(P2D)'
@@ -68,14 +69,14 @@ public class WatermarkDefinitionTest {
     expectedInDateTime = String.format("(%s,%s)",
         "2020-04-02T00:00:00.000-07:00",
         DateTime.now().withZone(timeZone).minusDays(2).dayOfMonth().roundFloorCopy());
-    jsonDef = "[{\"name\":\"system\",\"type\":\"datetime\",\"range\":{\"from\":\"2020-04-02\",\"to\":\"P2D\"}}]";
-    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef, false, WorkUnitPartitionTypes.WEEKLY,
+    jsonDef1 = "[{\"name\":\"system\",\"type\":\"datetime\",\"range\":{\"from\":\"2020-04-02\",\"to\":\"P2D\"}}]";
+    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef1, false, WorkUnitPartitionTypes.WEEKLY,
         expectedInMillis, expectedInDateTime);
-    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef, true, WorkUnitPartitionTypes.WEEKLY,
+    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef1, true, WorkUnitPartitionTypes.WEEKLY,
         expectedInMillis, expectedInDateTime);
-    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef, false, WorkUnitPartitionTypes.MONTHLY,
+    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef1, false, WorkUnitPartitionTypes.MONTHLY,
         expectedInMillis, expectedInDateTime);
-    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef, true, WorkUnitPartitionTypes.MONTHLY,
+    helperPartitionPrecisionAtDayLevelForWeeklyAndMonthlyPartitionTypes(jsonDef1, true, WorkUnitPartitionTypes.MONTHLY,
         expectedInMillis, expectedInDateTime);
   }
 
@@ -113,10 +114,6 @@ public class WatermarkDefinitionTest {
     // If partial partition is set to true, time should not round to 00:00:00-000
     Assert.assertNotEquals(definitions.getRangeInDateTime().getRight(),
         DateTime.now().withZone(timeZone).dayOfMonth().roundFloorCopy());
-    definitions = new WatermarkDefinition(defArray.get(0).getAsJsonObject(), false);
-    // If partial partition is set to false, time should be rounded to 00:00:00-000
-    Assert.assertEquals(definitions.getRangeInDateTime().getRight(),
-        DateTime.now().withZone(timeZone).dayOfMonth().roundFloorCopy());
   }
 
   @Test
@@ -127,37 +124,24 @@ public class WatermarkDefinitionTest {
     definitions = new WatermarkDefinition("primary", "2020-01-01", "P1D", false);
     WatermarkDefinition definitionsIsPartial = new WatermarkDefinition("primary", "2020-01-01", "P1D", true);
 
+    // P1D means truncates to day level
     Assert.assertEquals(definitions.getRangeInDateTime().getRight(),
         DateTime.now().withZone(timeZone).minusDays(1).dayOfMonth().roundFloorCopy());
-
-    // the millis second difference can often fail the test
-    // truncating the seconds and milli seconds to ensure success
-    Assert.assertEquals(definitionsIsPartial.getRangeInDateTime().getRight().minuteOfDay().roundFloorCopy(),
-        DateTime.now().withZone(timeZone).minusDays(1).minuteOfDay().roundFloorCopy());
 
     // P2DT5H
     definitions = new WatermarkDefinition("primary", "2020-01-01", "P2DT5H", false);
     definitionsIsPartial = new WatermarkDefinition("primary", "2020-01-01", "P2DT5H", true);
 
     Assert.assertEquals(definitions.getRangeInDateTime().getRight(),
-        DateTime.now().withZone(timeZone).minusDays(2).minusHours(5).dayOfMonth().roundFloorCopy());
-
-    // the millis second difference can often fail the test
-    // truncating the seconds and milli seconds to ensure success
-    Assert.assertEquals(definitionsIsPartial.getRangeInDateTime().getRight().minuteOfDay().roundFloorCopy(),
-        DateTime.now().withZone(timeZone).minusDays(2).minusHours(5).minuteOfDay().roundFloorCopy());
+        DateTime.now().withZone(timeZone).minusDays(2).minusHours(5).hourOfDay().roundFloorCopy());
 
     // P0DT7H
     definitions = new WatermarkDefinition("primary", "2020-01-01", "P0DT7H", false);
     definitionsIsPartial = new WatermarkDefinition("primary", "2020-01-01", "P0DT7H", true);
 
     Assert.assertEquals(definitions.getRangeInDateTime().getRight(),
-        DateTime.now().withZone(timeZone).minusHours(7).dayOfMonth().roundFloorCopy());
+        DateTime.now().withZone(timeZone).minusHours(7).hourOfDay().roundFloorCopy());
 
-    // the millis second difference can often fail the test
-    // truncating the seconds and milli seconds to ensure success
-    Assert.assertEquals(definitionsIsPartial.getRangeInDateTime().getRight().minuteOfDay().roundFloorCopy(),
-        DateTime.now().withZone(timeZone).minusHours(7).minuteOfDay().roundFloorCopy());
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -205,10 +189,6 @@ public class WatermarkDefinitionTest {
   @Test
   public void testGetDateTimeII() {
     definitions = new WatermarkDefinition("primary", "[{\"secondary\":\"2018\"}]");
-    Assert.assertEquals(definitions.getDateTime("2020-01-01 10:00:30").toString(),
-        "2020-01-01T10:00:30.000-08:00");
-
-    definitions.setTimezone(TZ_LOS_ANGELES);
     Assert.assertEquals(definitions.getDateTime("2020-01-01 10:00:30").toString(),
         "2020-01-01T10:00:30.000-08:00");
   }

--- a/docs/concepts/backfill.md
+++ b/docs/concepts/backfill.md
@@ -1,0 +1,16 @@
+# Backfill
+
+Backfilling is to reprocess a chunk of data in the past that is beyond the look-back process using grace
+period. For example, when grace period is 7 days, the flow will look back 7 days in each new execution to reprocess data
+since 7 days ago. But when we found data in 3 months ago was wrong, we will need to use backfill. 
+
+Backfilling is usually a one-time process, i.e., after backfilling, the flow needs to revert to its normal state. But some
+large backfill might need multiple executions. For example, to restate past year's data, we might need to backfill 
+month by month. 
+
+Backfilling will disregard the prior states and high watermarks because it is a onetime process. 
+
+Backfilling will be executed in incremental mode always, to avoid wiping out prior data. Generally backfill should update 
+the newly processed data on top of existing data.
+
+[Back to Summary](summary.md#backfill)

--- a/docs/concepts/summary.md
+++ b/docs/concepts/summary.md
@@ -6,6 +6,11 @@ Each system might require credentials be supplied in different ways. The authent
 methods are very system dependent. DIL generalizes the authentication mechanism so that
 many authentication schemes can be configured in similar way. 
 
+## [Backfill](backfill.md)
+
+Backfilling is to reprocess a chunk of data in the past that is beyond the look-back process using grace
+period.
+
 ## [Encryption Methods](encryption-method.md)
 
 There are several types of encryption, and each can engage different methods. Encryption can be used in the following scenarios:

--- a/docs/concepts/watermark.md
+++ b/docs/concepts/watermark.md
@@ -27,7 +27,7 @@ before current day. `m` can be any natural number between 0 and 23,
 it defines m hours before the current time. The hour part is optional.
 Examples: P0D, P1D, P0DT7H. 
 
-"**-**" (Hyphen) can be used in `to` as a shortcut for "P0D".
+"**-**" (Hyphen) can be used in `to` as a shortcut for "P0DT0H0M".
 
 The `from` datetime is usually static, and `to` datetime is usually dynamic. 
 see [ms.watermark](https://github.com/linkedin/data-integration-library/blob/master/docs/parameters/ms.watermark.md). 

--- a/docs/how-to/backfill.md
+++ b/docs/how-to/backfill.md
@@ -1,0 +1,27 @@
+# How to Backfill
+
+Backfilling is to reprocess a chunk of data in the past that is beyond the look-back process using grace
+period. Backfill works for incrementally processed flows; there is no need for backfill in snapshot only flows.
+
+## To Backfill a Recent Period
+
+If data in a recent period went bad or missing, the quick fix is to set [ms.grace.period.days](../parameters/ms.grace.period.days.md) to
+a large enough number to cover that period. 
+
+If after expanding grace period, the number of work units becomes too large, which often happens when watermark is partitioned and there
+are unit watermarks, try the following to limit the number of work units in one execution. And repeat for other work units accordingly.
+
+- Use the filters [ms.secondary.input](../parameters/ms.secondary.input.md) to select only a subset of units in each execution
+- Only pick a few units in a unit watermark in each execution, see [ms.watermark](../parameters/ms.watermark.md)
+
+## To Backfill a Far-back Period
+
+If data in a far-back period went bad or missing, and using grace period extension leads to too many work units or too much 
+inefficiency, a former backfill is needed. To carry out a former backfill, set the following:
+
+- `ms.backfill=true`
+- set `ms.watermark` to the target period 
+
+If the target period is too wide, it can be broke up to multiple segments, using a piecemeal backfill.  
+
+[Back to Summary](summary.md#how-to-backfill)

--- a/docs/how-to/bootstrap.md
+++ b/docs/how-to/bootstrap.md
@@ -1,0 +1,11 @@
+# How to Bootstrap
+
+Bootstrap is to extract the whole history of a snapshot_append dataset from the source.
+
+To -bootstrap the whole history for a snapshot_append flow, use the following example to trigger a full extract:
+
+- Make sure there is no state store history from testing
+- Start the flow
+- Make sure `extract.is.full` is `false` after the first run 
+
+[Back to Summary](summary.md#how-to-re-bootstrap)

--- a/docs/how-to/re-bootstrap.md
+++ b/docs/how-to/re-bootstrap.md
@@ -1,0 +1,23 @@
+# How to Bootstrap
+
+Re-bootstrap is to re-extract the whole history of a snapshot_append dataset from the source. 
+
+To re-bootstrap the whole history for a snapshot_append flow, use the following examples to trigger a full extract:
+
+Option 1: 
+- Delete the whole history of state store 
+- Restart the flow
+- Safety check: Make sure `extract.is.full` is `false` after the execution, then resume incremental execution schedule.
+
+Option 2:
+- set the following and restart the flow
+- `extract.is.full=true`, explicitly set this to true
+- `ms.grace.period.days=2000`, set this to a larger enough value to cover all history
+- `ms.work.unit.parallelism.max=5000`, set this to a larger enough value
+- `ms.watermark=[{"name": "system","type": "datetime", "range": {"from": "2018-01-01", "to": "2019-01-01"}}]`
+- revert the above after the flow finishes
+
+To re-bootstrap a large dataset, use option 2 with a small range to get start, after that, follow [backfill](backfill.md) 
+instructions to backfill the rest in chunks. 
+
+[Back to Summary](summary.md#how-to-bootstrap)

--- a/docs/how-to/summary.md
+++ b/docs/how-to/summary.md
@@ -44,4 +44,17 @@ every once a while (e.g., every 15 minutes) until the status turns to ready or t
 downloading scenario, the status checking job can keep checking the availability of source data until they are
 present or timeout.
 
+# [How to Bootstrap](bootstrap.md)
+
+Bootstrap is to extract the whole history of a snapshot_append dataset from the source.
+
+# [How to Re-bootstrap](re-bootstrap.md)
+
+Re-bootstrap is to re-extract the whole history of a snapshot_append dataset from the source.
+
+# [How to Backfill](backfill.md)
+
+Backfilling is to reprocess a chunk of data in the past that is beyond the look-back process using grace
+period. Backfill works for incrementally processed flows; there is no need for backfill in snapshot only flows.
+
 

--- a/docs/parameters/ms.backfill.md
+++ b/docs/parameters/ms.backfill.md
@@ -1,0 +1,44 @@
+# ms.backfill
+
+**Tags**:
+
+**Type**: boolean
+
+**Format**: true/false
+
+**Default value**: false
+
+## Related
+- [ms.watermark](ms.watermark.md)
+- [ms.work.unit.partition](ms.work.unit.partition.md)
+- [ms.secondary.input](ms.secondary.input.md)
+
+## Description
+
+Backfilling is to reprocess a chunk of data in the past that is beyond the look-back process using grace
+period. For example, when grace period is 7 days, the flow will look back 7 days in each new execution to reprocess data
+since 7 days ago. But when we found data in 3 months ago was wrong, we will need to use backfill.
+
+Backfilling is usually a one-time process, i.e., after backfilling, the flow needs to revert to its normal state. But some
+large backfill might need multiple executions. For example, to restate past year's data, we might need to backfill
+month by month.
+
+Backfilling will disregard the prior states and high watermarks because it is a onetime process.
+
+Backfilling will be executed in incremental mode always, to avoid wiping out prior data. Generally backfill should update
+the newly processed data on top of existing data.
+
+## Example
+
+In a snapshot append flow, we found that there was an issue between 2020-12-01 and 2020-12-15, we can do: 
+- `ms.backfill=true`
+- `ms.watermark=[{"name": "system","type": "datetime", "range": {"from": "2020-12-01", "to": "2020-12-15"}}]`
+
+Additionally, we can change [ms.work.unit.partition](ms.work.unit.partition.md) to suit the new data range.
+
+Additionaly, we can change [ms.secondary.input](ms.secondary.input.md) using filters to limit the number of work units,
+or limit backfilling to certain units. 
+
+After backfilling, revert the properties. 
+
+[back to summary](summary.md#msbackfill)

--- a/docs/parameters/ms.watermark.md
+++ b/docs/parameters/ms.watermark.md
@@ -58,12 +58,11 @@ or `yyyy-MM-ddTHH:mm:ss.SSSSSSz`. For example: "2020-01-01". Hour and below grai
 are optional. Timezone is optional, and the default is PST. 
 - **-(hyphen)**: Hyphen represents the current date time. It will be converted to 
 system date during the work unit generation phase. 
-- **PxDTyH([ISO 8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations))**:
+- **PxDTyHzM([ISO 8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations))**:
 A ISO duration is interpreted as a datetime 
-that is `PxDTyH` **preceding** current date time. For example, if the definition
+that is `PxDTyHzM` **preceding** current date time. For example, if the definition
 is P1D, then it means a date time value (milliseconds) of 1 day before current
-date time (milliseconds). Apparently, hypen (-) is just a shorthand for P0D. 
-This format of presentation is interpreted per system date. 
+date time (milliseconds). Apparently, hypen (-) is just a shorthand for P0DT0H0M. 
 
 _The `from` value of a datetime watermark is usually static_.
 The importance of keeping `from` static is that partitions are generated 
@@ -98,15 +97,16 @@ _On the contrary, `to` value of a datetime watermark is usually dynamic_. Most
 commonly, it is "-". The `to` value can be PxD if the reference timeframe has to 
 end by certain number of days ago. 
 
-For multi-day partitioning, i.e. monthly and weekly partitioning, the `to` value
-is rounded to day level to avoid generating empty partitions under certain situations.
-For example, 
-without rounding, a weekly partition from Monday (milliseconds of midnight) to
-Monday (milliseconds of current time) could be generated on Mondays. That kind of 
-partitions can generate an empty range if the watermark is formatted as
-yyyy-MM-dd strings. In order to avoid rounding of `to` value to day level, 
-`to` can be defined as "P0DT0H", indicating DIL to round only to hour level. 
-  
+When `from` or `to` are specified using IOS duration format, the actual date time is rounded. 
+- PxD will round to day level by truncating hours and below precision
+- PxDTyH will round to hour level by truncating minutes and below precision
+- PxDTyHzM will round to minute level by truncating seconds and below precision
+
+When `from` or `to` are specified using IOS duration format, it can have an optional timezone code. 
+The ISO duration string and timezone code are concatenated by a ".". The timezone codes includes UTC, GMT, Amerca/Los_Angeles etc., for example:
+- `P0D.UTC`
+- `P0D.America/Los_Angeles`
+
 #### datetime watermark examples
 
 `ms.watermark=[{"name": "system","type": "datetime","range": {"from": "2019-01-01", "to": "-"}}]`

--- a/docs/parameters/summary.md
+++ b/docs/parameters/summary.md
@@ -29,9 +29,10 @@ including parameters and payloads to data lake through Kafka.
 ms.authentication job property defines the authentication of a request. It works with HTTP protocol only 
 for now, but could be used in other protocols. 
 
-## ms.backfill
+## [ms.backfill](ms.backfill.md)
 
-This is for future back fill automation. It has no use currently.  
+Backfilling is to reprocess a chunk of data in the past that is beyond the look-back process using grace
+period. 
 
 ## [ms.call.interval.millis](ms.call.interval.millis.md)
 


### PR DESCRIPTION
Allow timezone specified in time watermark with ISO duration format. Because ISO duration represents an offset, the base is now(). But that it is timezone dependent when it comes to milli-seconds. When ISO duration is calculated with rounding, P0D based on UTC will be different from P0D based on PST. 

Allow more precise rounding control based on ISO duration string instead of using is partial flag and multi-day partition flag. The previous rounding algorithm is hard to understand and incomplete. 
- PxD will round to day level by truncating hours and below precision
- PxDTyH will round to hour level by truncating minutes and below precision
- PxDTyHzM will round to minute level by truncating seconds and below precision

Other changes:
- Remove max date time partition check as it can lead to unexpected reduction of partitions
- Deprecate partial partition flag
- Document backfill and bootstrap concepts