### PR TITLE
Allow CSV schema define columns in different order from the header

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/AvroExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/AvroExtractor.java
@@ -191,7 +191,8 @@ public class AvroExtractor extends MultistageExtractor<Schema, GenericRecord> {
         List<String> schemaColumns = new ArrayList<>(new JsonIntermediateSchema(jobKeys.getOutputSchema())
             .getColumns().keySet());
         List<String> fieldNames = AvroSchemaUtils.getSchemaFieldNames(avroExtractorKeys.getAvroOutputSchema());
-        avroExtractorKeys.setIsValidOutputSchema(SchemaUtils.isValidOutputSchema(schemaColumns, fieldNames));
+        avroExtractorKeys.setIsValidOutputSchema(
+            SchemaUtils.isValidSchemaDefinition(schemaColumns, fieldNames, jobKeys.getDerivedFields().size()));
       }
     } catch (Exception e) {
       LOG.error("Source Error: {}", e.getMessage());

--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/JsonExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/JsonExtractor.java
@@ -147,14 +147,7 @@ public class JsonExtractor extends MultistageExtractor<JsonArray, JsonObject> {
    */
   @Override
   public JsonArray getSchema() {
-    LOG.debug("Retrieving schema definition");
-    JsonArray schemaArray = super.getOrInferSchema();
-    Assert.assertNotNull(schemaArray);
-    if (jobKeys.getDerivedFields().size() > 0 && JsonUtils.get(StaticConstants.KEY_WORD_COLUMN_NAME,
-        jobKeys.getDerivedFields().keySet().iterator().next(), StaticConstants.KEY_WORD_COLUMN_NAME, schemaArray) == JsonNull.INSTANCE) {
-      schemaArray.addAll(addDerivedFieldsToAltSchema());
-    }
-    return schemaArray;
+    return getSchemaArray();
   }
 
   @Nullable

--- a/cdi-core/src/main/java/com/linkedin/cdi/keys/CsvExtractorKeys.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/keys/CsvExtractorKeys.java
@@ -4,11 +4,13 @@
 
 package com.linkedin.cdi.keys;
 
+import com.beust.jcommander.internal.Lists;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -35,7 +37,7 @@ public class CsvExtractorKeys extends ExtractorKeys {
   // This is necessary as the input stream can only be read once
   private Deque<String[]> sampleRows = new ArrayDeque<>();
   private String[] headerRow;
-  private Set<Integer> columnProjection = new HashSet<>();
+  private List<Integer> columnProjection = Lists.newArrayList();
   private Boolean isValidOutputSchema = true;
   private String defaultFieldType = StringUtils.EMPTY;
 
@@ -99,11 +101,11 @@ public class CsvExtractorKeys extends ExtractorKeys {
     this.headerRow = headerRow;
   }
 
-  public Set<Integer> getColumnProjection() {
+  public List<Integer> getColumnProjection() {
     return columnProjection;
   }
 
-  public void setColumnProjection(Set<Integer> columnProjection) {
+  public void setColumnProjection(List<Integer> columnProjection) {
     this.columnProjection = columnProjection;
   }
 

--- a/cdi-core/src/test/java/com/linkedin/cdi/configuration/MultistagePropertiesIndividualTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/configuration/MultistagePropertiesIndividualTest.java
@@ -98,7 +98,7 @@ public class MultistagePropertiesIndividualTest {
     csv.addProperty("defaultFieldType", "xxx");
     csv.addProperty("fieldSeparator", "u0003");
     csv.addProperty("recordSeparator", "u0003");
-    csv.addProperty("columnProjection", "xxx");
+    csv.addProperty("columnProjection", "1,2,3");
     csv.addProperty("maxFailures", 1);
     csv.addProperty("keepNullString", true);
     state.setProp("ms.csv", csv.toString());
@@ -124,6 +124,11 @@ public class MultistagePropertiesIndividualTest {
     state.setProp("ms.csv", csv.toString());
     Assert.assertFalse(MSTAGE_CSV.isValid(state));
 
+    // column projection has to be numbers or ranges of numbers
+    csv = new JsonObject();
+    csv.addProperty("columnProjection", "x,y,z");
+    state.setProp("ms.csv", csv.toString());
+    Assert.assertFalse(MSTAGE_CSV.isValid(state));
   }
 
   @Test

--- a/cdi-core/src/test/java/com/linkedin/cdi/filter/CsvSchemaBasedFilterTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/filter/CsvSchemaBasedFilterTest.java
@@ -1,0 +1,42 @@
+// Copyright 2021 LinkedIn Corporation. All rights reserved.
+// Licensed under the BSD-2 Clause license.
+// See LICENSE in the project root for license information.
+
+package com.linkedin.cdi.filter;
+
+import com.google.common.collect.Lists;
+import com.google.gson.JsonArray;
+import com.linkedin.cdi.keys.CsvExtractorKeys;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class CsvSchemaBasedFilterTest {
+  @Test
+  public void testFilter() {
+    String[] input = "AA,BB,CC".split(",");
+    List<Integer> columnProjection = Lists.newArrayList(0, 2, 1);
+    String[] output = new CsvSchemaBasedFilter(new JsonArray(),
+        new CsvExtractorKeys()).filter(input, columnProjection);
+    Assert.assertEquals(output[0], input[0]);
+    Assert.assertEquals(output[1], input[2]);
+    Assert.assertEquals(output[2], input[1]);
+
+    columnProjection = Lists.newArrayList(0, 2, 1, 0);
+    output = new CsvSchemaBasedFilter(new JsonArray(),
+        new CsvExtractorKeys()).filter(input, columnProjection);
+    Assert.assertEquals(output[0], input[0]);
+    Assert.assertEquals(output[1], input[2]);
+    Assert.assertEquals(output[2], input[1]);
+    Assert.assertEquals(output[3], input[0]);
+
+    columnProjection = Lists.newArrayList(0, 1, 2, 3);
+    output = new CsvSchemaBasedFilter(new JsonArray(),
+        new CsvExtractorKeys()).filter(input, columnProjection);
+    Assert.assertTrue(output[3].isEmpty());
+
+    Assert.assertNull(new CsvSchemaBasedFilter(new JsonArray(),
+        new CsvExtractorKeys()).filter(input, Lists.newArrayList()));
+  }
+}

--- a/cdi-core/src/test/java/com/linkedin/cdi/util/SchemaUtilsTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/util/SchemaUtilsTest.java
@@ -18,25 +18,30 @@ public class SchemaUtilsTest {
 
   @Test
   public void testIsValidOutputSchema() {
-    // valid schema
+    // valid schema, subset same order
     List<String> schemaColumns = Arrays.asList("a", "b");
     List<String> sourceColumns = Arrays.asList("a", "B", "C");
-    Assert.assertTrue(SchemaUtils.isValidOutputSchema(schemaColumns, sourceColumns));
+    Assert.assertTrue(SchemaUtils.isValidSchemaDefinition(schemaColumns, sourceColumns, 0));
 
-    // valid schema
+    // valid schema, subset with derived fields
+    schemaColumns = Arrays.asList("a", "b", "x");
+    sourceColumns = Arrays.asList("a", "b");
+    Assert.assertTrue(SchemaUtils.isValidSchemaDefinition(schemaColumns, sourceColumns, 1));
+
+    // valid schema, subset with skipped columns
     schemaColumns = Arrays.asList("a", "c");
     sourceColumns = Arrays.asList("a", "B", "C");
-    Assert.assertTrue(SchemaUtils.isValidOutputSchema(schemaColumns, sourceColumns));
+    Assert.assertTrue(SchemaUtils.isValidSchemaDefinition(schemaColumns, sourceColumns, 0));
 
-    // some columns in the schema is nowhere to be found in the source
+    // some columns in the schema is not in the source
     schemaColumns = Arrays.asList("a", "e");
     sourceColumns = Arrays.asList("a", "B", "C");
-    Assert.assertFalse(SchemaUtils.isValidOutputSchema(schemaColumns, sourceColumns));
+    Assert.assertFalse(SchemaUtils.isValidSchemaDefinition(schemaColumns, sourceColumns, 0));
 
-    // order mismatch
+    // order mismatch is allowed
     schemaColumns = Arrays.asList("c", "a", "b");
     sourceColumns = Arrays.asList("a", "B", "C");
-    Assert.assertFalse(SchemaUtils.isValidOutputSchema(schemaColumns, sourceColumns));
+    Assert.assertTrue(SchemaUtils.isValidSchemaDefinition(schemaColumns, sourceColumns, 0));
   }
 
   @Test


### PR DESCRIPTION
Previously, in order to override schema definition of a CSV source, an explicit schema can be defined in ms.output.schema. The requirement is that the columns have to be ordered the same way as the source data, otherwise, column projection has to be specified so that source columns are mapped to output columns properly. 

As the CSV source system evolves, the order of source columns can change. In such case, the source columns and output columns will be incorrectly mapped. 

For example, when the source columns were [A, B, C], the ms.output.schema was defined as [A, B, C] as well, then when source columns changed to [B, C, A], the output schema and source schema no longer matching, and DIL simply took the first 3 columns from source data, and assigned to output. That led to wrong results. 

The new approach will build an internal column projection of [2, 0, 1] after the source column change. 

The **caveat** is that when a column projection is defined explicitly through columnProjection property of ms.csv, that column projection will always take priority. So in order to use this dynamic column projection, columnProject property should not be set in ms.csv. 