### PR TITLE
Upgrade Gobblin to 0.17.0-dev-174

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   ext.avroVersion = '1.8.1'
   ext.awsVersion = '2.10.15'
   ext.findBugsVersion = '3.0.0'
-  ext.gobblinVersion = '0.15.0-dev-9467'
+  ext.gobblinVersion = '0.17.0-dev-174'
   ext.hadoopVersion = '2.3.0'
   ext.hiveVersion = '1.0.1'
   ext.javaVersion = JavaVersion.VERSION_1_8

--- a/cdi-core/build.gradle
+++ b/cdi-core/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   compile externalDependency.'commonsLang3'
   compile externalDependency.'testng'
   compile externalDependency.'jhyde'
+  compile externalDependency.'opencsv'
 
   runtime externalDependency.'gobblin-azkaban'
   runtime externalDependency.'gobblin-kafka-08'
@@ -75,6 +76,7 @@ configurations {
   all*.exclude group: 'ch.qos.logback'
   all*.exclude group: 'com.ibm.icu', module: 'icu4j'
   all*.exclude group: 'org.pentaho'
+  all*.exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
 }
 
 shadowJar {

--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/TextExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/TextExtractor.java
@@ -26,8 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
 import javax.annotation.Nullable;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,15 +35,18 @@ import org.testng.Assert;
 /**
  * TextExtractor takes an InputStream, applies proper preprocessors, and returns a String output
  */
-@Slf4j
 public class TextExtractor extends MultistageExtractor<JsonArray, JsonObject> {
-  private static final Logger logger = LoggerFactory.getLogger(TextExtractor.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TextExtractor.class);
 
   private final static int TEXT_EXTRACTOR_BYTE_LIMIT = 1048576;
   private final static int BUFFER_SIZE = 8192;
   private final static String TEXT_EXTRACTOR_SCHEMA =
       "[{\"columnName\":\"output\",\"isNullable\":true,\"dataType\":{\"type\":\"string\"}}]";
-  @Getter
+
+  public JsonExtractorKeys getJsonExtractorKeys() {
+    return jsonExtractorKeys;
+  }
+
   private JsonExtractorKeys jsonExtractorKeys = new JsonExtractorKeys();
 
   public TextExtractor(WorkUnitState state, JobKeys jobKeys) {
@@ -100,7 +101,7 @@ public class TextExtractor extends MultistageExtractor<JsonArray, JsonObject> {
       this.jsonExtractorKeys.setTotalCount(1);
       StringBuffer output = new StringBuffer();
       if (workUnitStatus.getBuffer() == null) {
-        logger.warn("Received a NULL InputStream, end the work unit");
+        LOG.warn("Received a NULL InputStream, end the work unit");
         return null;
       } else {
         try {
@@ -118,7 +119,7 @@ public class TextExtractor extends MultistageExtractor<JsonArray, JsonObject> {
           JsonObject outputJson = addDerivedFields(jsonObject);
           return outputJson;
         } catch (Exception e) {
-          logger.error("Error while extracting from source or writing to target", e);
+          LOG.error("Error while extracting from source or writing to target", e);
           this.state.setWorkingState(WorkUnitState.WorkingState.FAILED);
           return null;
         }
@@ -142,12 +143,12 @@ public class TextExtractor extends MultistageExtractor<JsonArray, JsonObject> {
         output.append(String.valueOf(buffer, 0, len));
         totalBytes += len;
         if (totalBytes > TEXT_EXTRACTOR_BYTE_LIMIT) {
-          logger.warn("Download limit of {} bytes reached for text extractor ", TEXT_EXTRACTOR_BYTE_LIMIT);
+          LOG.warn("Download limit of {} bytes reached for text extractor ", TEXT_EXTRACTOR_BYTE_LIMIT);
           break;
         }
       }
       is.close();
-      logger.info("TextExtractor: written {} bytes ", totalBytes);
+      LOG.info("TextExtractor: written {} bytes ", totalBytes);
     } catch (IOException e) {
       throw new RuntimeException("Unable to extract text in TextExtractor", e);
     }

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -127,7 +127,7 @@ ext.externalDependency = [
     "googleAnalytics": "com.google.apis:google-api-services-analytics:v3-rev134-1.22.0",
     "googleDrive": "com.google.apis:google-api-services-drive:v3-rev42-1.22.0",
     "googleWebmasters": "com.google.apis:google-api-services-webmasters:v3-rev17-1.22.0",
-    "opencsv": "com.opencsv:opencsv:3.8",
+    "opencsv": "com.opencsv:opencsv:3.9",
     "grok": "io.thekraken:grok:0.1.5",
     "hadoopAdl" : "org.apache.hadoop:hadoop-azure-datalake:3.0.0-alpha2",
     "orcMapreduce":"org.apache.orc:orc-mapreduce:1.6.5:nohive",


### PR DESCRIPTION
Upgrade Gobblin to the latest version as of end of 2021, which is 0.17.0-dev-174. The upgrade also requires an upgrade of OpenCsv to 3.9 otherwise version 3.8 and version 3.9 will be both pulled in and causing runtime NSME. 