### PR TITLE
Add a close() method to SecretManager abstract class

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/util/SecretManager.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/util/SecretManager.java
@@ -36,6 +36,16 @@ public abstract class SecretManager {
    */
   abstract public String encrypt(String input);
 
+  /**
+   * Close out any resources allocated. The default does nothing.
+   */
+  public void close() { };
+
+  /**
+   * The singleton instantiation method
+   * @param state configuration state object
+   * @return the singleton SecretManager instance
+   */
   static public SecretManager getInstance(State state) {
     if (SecretManager.manager != null) {
       return SecretManager.manager;


### PR DESCRIPTION
Add a close() method to SecretManager abstract class so that implementations can close out any allocated resources. 