### PR TITLE
Grouping kafka properties into single object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,5 @@ package-lock.json
 
 # generated java files
 **/gen-java/
-
+**/generatedJava
 temp/

--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/KafkaProperties.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/KafkaProperties.java
@@ -1,0 +1,151 @@
+// Copyright 2021 LinkedIn Corporation. All rights reserved.
+// Licensed under the BSD-2 Clause license.
+// See LICENSE in the project root for license information.
+
+package com.linkedin.cdi.configuration;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.gson.JsonObject;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.gobblin.configuration.State;
+
+import static com.linkedin.cdi.configuration.StaticConstants.*;
+
+
+/**
+ * Kafka Parameters with SSL parameters
+ */
+public class KafkaProperties extends JsonObjectProperties {
+
+  private static final String BOOTSTRAP_SERVERS = "bootstrapServers";
+  private static final String VALUE_SERIALIZER = "valueSerializer";
+  private static final String KEY_SERIALIZER = "keySerializer";
+  private static final String CLIENT_ID = "clientId";
+  private static final String TOPIC_NAME = "topicName";
+  private static final String SCHEMA_REGISTRY_URL = "schemaRegistryUrl";
+  private static final String SCHEMA_REGISTRY_CLASS = "schemaRegistryClass";
+  private static final String DEFAULT_CLIENT_ID = "cdiKafka";
+  private static final String SECURITY_PROTOCOL = "securityProtocol";
+  private static final String KEY_STORE_TYPE = "keyStoreType";
+  private static final String KEY_STORE_PATH = "keyStorePath";
+  private static final String KEY_STORE_PASSWORD = "keyStorePassword";
+  private static final String KEY_PASSWORD = "keyPassword";
+  private static final String TRUST_STORE_PATH = "trustStorePath";
+  private static final String TRUST_STORE_PASSWORD = "trustStorePassword";
+  private static final String KAFKA_BOOTSTRAP_SERVERS = "bootstrap.servers";
+  private static final String KAFKA_VALUE_SERIALIZER = "value.serializer";
+  private static final String KAFKA_KEY_SERIALIZER = "key.serializer";
+  private static final String KAFKA_KEY_STORE_TYPE = "ssl.keystore.type";
+  private static final String KAFKA_KEY_STORE_PATH = "ssl.keystore.location";
+  private static final String KAFKA_KEY_STORE_PASSWORD = "ssl.keystore.password";
+  private static final String KAFKA_KEY_PASSWORD = "ssl.key.password";
+  private static final String KAFKA_TRUST_STORE_PATH = "ssl.truststore.location";
+  private static final String KAFKA_TRUST_STORE_PASSWORD = "ssl.truststore.password";
+  private static final String KAFKA_SCHEMA_REGISTRY_CLASS = "kafka.schemaRegistry.class";
+  private static final String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schemaRegistry.url";
+  private static final String KAFKA_SECURITY_PROTOCOL = "security.protocol";
+
+  final private static List<String> essentialAttributes =
+      Lists.newArrayList(BOOTSTRAP_SERVERS, VALUE_SERIALIZER, KEY_SERIALIZER, TOPIC_NAME, SECURITY_PROTOCOL);
+
+  // Translate essential Kafka producer config from ms parameters. More kafka producer configs can pass based on open source kafka documentation separately
+  public static final ImmutableMap<String, String> kafkaConfigMapping =
+      ImmutableMap.<String, String>builder().put(BOOTSTRAP_SERVERS, KAFKA_BOOTSTRAP_SERVERS)
+          .put(VALUE_SERIALIZER, KAFKA_VALUE_SERIALIZER)
+          .put(KEY_SERIALIZER, KAFKA_KEY_SERIALIZER)
+          .put(KEY_STORE_TYPE, KAFKA_KEY_STORE_TYPE)
+          .put(KEY_STORE_PATH, KAFKA_KEY_STORE_PATH)
+          .put(KEY_STORE_PASSWORD, KAFKA_KEY_STORE_PASSWORD)
+          .put(KEY_PASSWORD, KAFKA_KEY_PASSWORD)
+          .put(TRUST_STORE_PATH, KAFKA_TRUST_STORE_PATH)
+          .put(TRUST_STORE_PASSWORD, KAFKA_TRUST_STORE_PASSWORD)
+          .put(SCHEMA_REGISTRY_CLASS, KAFKA_SCHEMA_REGISTRY_CLASS)
+          .put(SCHEMA_REGISTRY_URL, KAFKA_SCHEMA_REGISTRY_URL)
+          .put(SECURITY_PROTOCOL, KAFKA_SECURITY_PROTOCOL)
+          .build();
+
+  @Override
+  public boolean isValid(State state) {
+    if (super.isValid(state) && !super.isBlank(state)) {
+      JsonObject value = GSON.fromJson(state.getProp(getConfig()), JsonObject.class);
+      return essentialAttributes.stream().allMatch(p -> value.has(p));
+    }
+    return super.isValid(state);
+  }
+
+  /**
+   * Constructor with implicit default value
+   * @param config property name
+   */
+  KafkaProperties(String config) {
+    super(config);
+  }
+
+  public String getBootstrapServers(State state) {
+    JsonObject value = get(state);
+    if (value.has(BOOTSTRAP_SERVERS)) {
+      return value.get(BOOTSTRAP_SERVERS).getAsString();
+    }
+    return StringUtils.EMPTY;
+  }
+
+  public String getValueSerializer(State state) {
+    JsonObject value = get(state);
+    if (value.has(VALUE_SERIALIZER)) {
+      return value.get(VALUE_SERIALIZER).getAsString();
+    }
+    return StringUtils.EMPTY;
+  }
+
+  public String getKeySerializer(State state) {
+    JsonObject value = get(state);
+    if (value.has(KEY_SERIALIZER)) {
+      return value.get(KEY_SERIALIZER).getAsString();
+    }
+    return StringUtils.EMPTY;
+  }
+
+  public String getClientId(State state) {
+    JsonObject value = get(state);
+    if (value.has(CLIENT_ID)) {
+      return value.get(CLIENT_ID).getAsString();
+    }
+    return DEFAULT_CLIENT_ID;
+  }
+
+  public String getTopicName(State state) {
+    JsonObject value = get(state);
+    if (value.has(TOPIC_NAME)) {
+      return value.get(TOPIC_NAME).getAsString();
+    }
+    return StringUtils.EMPTY;
+  }
+
+  public String getSchemaRegistryUrl(State state) {
+    JsonObject value = get(state);
+    if (value.has(SCHEMA_REGISTRY_URL)) {
+      return value.get(SCHEMA_REGISTRY_URL).getAsString();
+    }
+    return StringUtils.EMPTY;
+  }
+
+  public String getSchemaRegistryClass(State state) {
+    JsonObject value = get(state);
+    if (value.has(SCHEMA_REGISTRY_CLASS)) {
+      return value.get(SCHEMA_REGISTRY_CLASS).getAsString();
+    }
+    return StringUtils.EMPTY;
+  }
+
+  public void fillKafkaConfig(State state) {
+    JsonObject value = get(state);
+    for (Map.Entry<String, String> entry : kafkaConfigMapping.entrySet()) {
+      if (StringUtils.isNotBlank(value.get(entry.getKey()).getAsString()) && value.has(entry.getKey())) {
+        state.setProp(entry.getValue(), value.get(entry.getKey()).getAsString());
+      }
+    }
+  }
+}

--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/PropertyCollection.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/PropertyCollection.java
@@ -142,15 +142,8 @@ public interface PropertyCollection {
   JsonObjectProperties MSTAGE_HTTP_STATUS_REASONS = new JsonObjectProperties("ms.http.status.reasons");
   StringProperties MSTAGE_JDBC_SCHEMA_REFACTOR = new StringProperties("ms.jdbc.schema.refactor", "none");
   StringProperties MSTAGE_JDBC_STATEMENT = new StringProperties("ms.jdbc.statement");
-  StringProperties MSTAGE_KAFKA_BROKERS = new StringProperties("ms.kafka.brokers");
-  StringProperties MSTAGE_KAFKA_SCHEMA_REGISTRY_URL = new StringProperties("ms.kafka.schema.registry.url");
-  StringProperties MSTAGE_KAFKA_SCHEMA_REGISTRY_CLASS = new StringProperties("ms.kafka.schema.registry.class");
-  StringProperties MSTAGE_KAFKA_CLIENT_ID = new StringProperties("ms.kafka.clientId");
-  StringProperties MSTAGE_KAFKA_TOPIC_NAME = new StringProperties("ms.kafka.audit.topic.name");
-  StringProperties MSTAGE_KAFKA_EVENT_TOPIC_NAME = new StringProperties("ms.kafka.events.topic.name");
   BooleanProperties MSTAGE_METRICS_ENABLED = new BooleanProperties("ms.metrics.enabled", Boolean.FALSE);
-  StringProperties MSTAGE_KAFKA_VALUE_SERIALIZER = new StringProperties("ms.kafka.value.serializer");
-  StringProperties MSTAGE_KAFKA_KEY_SERIALIZER = new StringProperties("ms.kafka.key.serializer");
+  KafkaProperties MSTAGE_KAFKA_PROPERTIES = new KafkaProperties("ms.kafka");
   StringProperties MSTAGE_REPORTER_CLASS = new StringProperties("ms.reporter.class",
       "com.linkedin.cdi.factory.producer.KafkaEventReporter");
 
@@ -343,10 +336,7 @@ public interface PropertyCollection {
       MSTAGE_HTTP_STATUS_REASONS,
       MSTAGE_JDBC_SCHEMA_REFACTOR,
       MSTAGE_JDBC_STATEMENT,
-      MSTAGE_KAFKA_BROKERS,
-      MSTAGE_KAFKA_SCHEMA_REGISTRY_URL,
-      MSTAGE_KAFKA_CLIENT_ID,
-      MSTAGE_KAFKA_TOPIC_NAME,
+      MSTAGE_KAFKA_PROPERTIES,
       MSTAGE_NORMALIZER_BATCH_SIZE,
       MSTAGE_OUTPUT_SCHEMA,
       MSTAGE_PAGINATION,

--- a/docs/parameters/categories.md
+++ b/docs/parameters/categories.md
@@ -8,6 +8,13 @@ The following job properties are essential for auditing function:
 - [ms.kafka.schema.registry.url](ms.kafka.schema.registry.url.md)
 - [ms.kafka.audit.topic.name](ms.kafka.audit.topic.name.md)
 
+# Monitoring Properties
+
+The following job properties are essential for monitoring:
+
+- [ms.metrics.enabled](ms.metrics.enabled.md)
+- [ms.kafka](ms.kafka.md)
+
 # Authentication Properties
 
 The following are related to authentication:

--- a/docs/parameters/ms.kafka.md
+++ b/docs/parameters/ms.kafka.md
@@ -1,0 +1,59 @@
+# ms.kafka
+
+**Tags**: 
+[monitoring](categories.md#monitoring-properties),
+
+**Type**: string
+
+**Format**: JsonObject
+
+**Default value**: {} (blank JsonObject)
+
+## Related 
+
+## Description 
+
+`ms.kafka` defines essential Kafka producer configs with ssl. 
+
+`ms.kafka` comes as a JsonObject, and it can have any of the following
+attributes:     
+
+- **bootstrapServers**, specifies the list of kafka brokers you are trying to connect to. This is a mandatory property to use kafka for reporting any events.
+- **valueSerializer**, specifies the name of the serializer class for the value that implements `org.apache.kafka.common.serialization.Serializer` interface
+- **keySerializer**, specifies the name of the serializer class for the key that implements `org.apache.kafka.common.serialization.Serializer` interface
+- **topicName**, specifies the name of the Kafka topic the event is emitted to.
+- **schemaRegistryClass**, is an optional parameter that specifics the name of schema registry class in case you host the data contract for kafka in a specific schema registry
+- **schemaRegistryUrl**, is an optional parameter that specifies the url of schema registry, typically schema registry itself can be a service that should be able to support REST API
+
+SSL attributes to connect to Kafka 
+- **securityProtocol**, specifies the type of SSL supported by default we set SSL protocol
+- **keyStoreType**, specifies keystore type default is `"pkcs12"`
+- **keyStorePath**, specifies file path to key store file
+- **keyStorePassword**, specifies the key to decrypt key store file
+- **keyPassword**, specifies the password to decrypt the key
+- **trustStorePath**, specifies the file path to trust store
+- **trustStorePassword**, specifies the key to decrypt trust store
+- **connectionTimeoutSeconds**, wait time for establishing a connection
+
+**Example**: 
+```
+{
+    "bootstrapServers": "kafka.corp.com:1000",
+    "valueSerializer": "org.apache.kafka.common.serialization.Serializer",
+    "keySerializer": "org.apache.kafka.common.serialization.Serializer",
+    "schemaRegistryUrl": "http://schemaregistry.corp.com:1001/schemaRegistry/schemas",
+    "schemaRegistryClass": "org.apache.gobblin.kafka.schemareg.LiKafkaSchemaRegistry",
+    "topicName": "CdiTrackingEvent",
+    "keyStoreType": "pkcs12",
+    "keyStorePath": "/User/test/identity.p12",
+    "keyStorePassword": "test_pass",
+    "keyPassword": "test_pass",
+    "trustStorePath": "/User/test/certs",
+    "trustStorePassword": "test_pass",
+    "securityProtocol": "SSL"
+}
+```
+
+Besides, if you need to pass additional Kafka producer related properties they can be passed as regular key value pairs in your job file. For more additional properties please refer to `https://kafka.apache.org/documentation/#producerconfigs`.
+
+[back to summary](summary.md#mskafkamskafka)

--- a/docs/parameters/summary.md
+++ b/docs/parameters/summary.md
@@ -244,22 +244,9 @@ The choices are `toupper`, `tolower`, or `none`
 `ms.jdbc.statement` specifies the SQL statement for data retrieval. The value
 can be any validate statement on any JDBC source.
 
-## [ms.kafka.brokers](ms.kafka.brokers.md)
+## [ms.kafka](ms.kafka)
 
-This specifies the Kafka broker host, such as `kafka.corp.com:1234`
-
-## [ms.kafka.clientId](ms.kafka.clientId.md)
-
-This specifies the Kafka client id, such as `dil-audit`
-
-## [ms.kafka.schema.registry.url](ms.kafka.schema.registry.url.md)
-
-`ms.kafka.schema.registry.url` specifies the auditing schema registry URL.
-
-## [ms.kafka.audit.topic.name](ms.kafka.audit.topic.name.md)
-
-`ms.kafka.audit.topic.name` specifies the auditing topic name, where
-DIL wil send auditing events to if auditing is enabled.
+[`ms.kafka`](ms.kafka.md) specifies the Kafka producer config, all the essential producer config can be grouped under this object.  
 
 ## [ms.normalizer.batch.size](ms.normalizer.batch.size.md)
 


### PR DESCRIPTION
Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### Description
- This PR merges various Kafka client parameters into a single `ms.kafka` JsonObject parameter. This reduces a lot of clutter in the config files. The config also includes accepting SSL-based config parameters specifically for Kafka clients. Included detailed documentation on different acceptable parameters. With the new changes metrics can be enabled by just 2 properties as mentioned below

```
ms.metrics.enabled=true
ms.kafka={
    "bootstrapServers": "kafka.corp.com:1000",
    "valueSerializer": "org.apache.kafka.common.serialization.Serializer",
    "keySerializer": "org.apache.kafka.common.serialization.Serializer",
    "schemaRegistryUrl": "http://schemaregistry.corp.com:1001/schemaRegistry/schemas",
    "schemaRegistryClass": "org.apache.gobblin.kafka.schemareg.LiKafkaSchemaRegistry",
    "topicName": "CdiTrackingEvent",
    "keyStoreType": "pkcs12",
    "keyStorePath": "/User/test/identity.p12",
    "keyStorePassword": "test_pass",
    "keyPassword": "test_pass",
    "trustStorePath": "/User/test/certs",
    "trustStorePassword": "test_pass",
    "securityProtocol": "SSL"
}
```