### PR TITLE
Process JDBC result set through temp file to reduce memory usage

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/FileDumpExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/FileDumpExtractor.java
@@ -186,7 +186,7 @@ public class FileDumpExtractor extends MultistageExtractor<String, String> {
 
       // create output stream after renaming the file with proper extensions if needed
       // if there is a output preprocessor, like GPG encryptor, specified
-      OutputStream os = FileSystem.create(fs, new Path(path), logPermission);;
+      OutputStream os = FileSystem.create(fs, new Path(path), logPermission);
       for (StreamProcessor<?> transformer : extractorKeys.getPreprocessors()) {
         if (transformer instanceof OutputStreamProcessor) {
           os = ((OutputStreamProcessor) transformer).process(os);


### PR DESCRIPTION
This change replaces ByteArrayInputStream with a temp file and file InputStream. For large datasets, ByteArrayInputStream can take huge amount of memory as all data have to cached in memory. By writing to temp file, data are processed in rows, thus save memory. Testing with Dynamics 365 Account object shows that XMX can be reduced to 4GB from 20GB for 1.5 million rows. 