### PR TITLE
Add CsvRangerGenerator converter

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/PropertyCollection.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/PropertyCollection.java
@@ -167,6 +167,11 @@ public interface PropertyCollection {
   };
 
   JsonArrayProperties MSTAGE_PAYLOAD_PROPERTY = new JsonArrayProperties("ms.payload.property");
+  // default: 50K, minimum: 1, maximum: -
+  LongProperties MSTAGE_RANGE_GENERATOR_BATCH_SIZE = new LongProperties("ms.range.generator.batch.size", 50000L, Long.MAX_VALUE, 1L);
+  //  set highest possible value to 10 Zs
+  StringProperties MSTAGE_RANGE_GENERATOR_MAX_VALUE = new StringProperties("ms.range.generator.max.value", "zzzzzzzzzz");
+
   JsonObjectProperties MSTAGE_RETENTION =
       new JsonObjectProperties("ms.retention") {
         @Override

--- a/cdi-core/src/main/java/com/linkedin/cdi/converter/CsvRangeGenerator.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/converter/CsvRangeGenerator.java
@@ -1,0 +1,116 @@
+// Copyright 2021 LinkedIn Corporation. All rights reserved.
+// Licensed under the BSD-2 Clause license.
+// See LICENSE in the project root for license information.
+
+package com.linkedin.cdi.converter;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.converter.Converter;
+import org.apache.gobblin.converter.SingleRecordIterable;
+import org.apache.gobblin.util.EmptyIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.cdi.configuration.PropertyCollection.*;
+import static com.linkedin.cdi.configuration.StaticConstants.*;
+
+
+/**
+ * This converter takes an ordered list of values and generates ranges
+ * per given batch size.
+ *
+ * Given a list [0...50] and batch size 10, it will generate ranges
+ * [0, 9]
+ * [10, 19]
+ * [20, 29]
+ * [30, 39]
+ * [40, 49]
+ * [50, 50]
+ */
+public class CsvRangeGenerator extends Converter<String, JsonArray, String[], JsonObject> {
+  private static final Logger LOG = LoggerFactory.getLogger(CsvRangeGenerator.class);
+  private JsonArray targetSchema;
+  private String rangeStart = null;
+  private String rangeEnd = null;
+  private int count = 0;
+  private String columnStart;
+  private String columnEnd;
+
+  private long batchSize = 0;
+  private String rangeMax = null;
+
+
+  @Override
+  public Converter<String, JsonArray, String[], JsonObject> init(WorkUnitState workUnit) {
+    // TODO create a default schema of 2 string columns
+    targetSchema = MSTAGE_TARGET_SCHEMA.get(workUnit);
+    Preconditions.checkArgument(targetSchema.size() == 2, "Target schema have to be 2 columns");
+    columnStart = targetSchema.get(0).getAsJsonObject().get(KEY_WORD_COLUMN_NAME).getAsString();
+    columnEnd = targetSchema.get(1).getAsJsonObject().get(KEY_WORD_COLUMN_NAME).getAsString();
+
+    // batchSize has to be positive integers
+    batchSize = MSTAGE_RANGE_GENERATOR_BATCH_SIZE.get(workUnit);
+    rangeMax = MSTAGE_RANGE_GENERATOR_MAX_VALUE.get(workUnit);
+    return this;
+  }
+
+  @Override
+  public JsonArray convertSchema(String inputSchema, WorkUnitState workUnit) {
+    Preconditions.checkNotNull(inputSchema, "inputSchema is required.");
+    return targetSchema;
+  }
+
+  @Override
+  public Iterable<JsonObject> convertRecord(JsonArray outputSchema, String[] inputRecord, WorkUnitState workUnit) {
+    if (inputRecord[0].equals(KEY_WORD_EOF)) {
+      // only output when there's at least one record
+      rangeEnd = rangeMax;
+      return outputIterable(1);
+    }
+
+    if (count == 0) {
+      rangeStart = inputRecord[0];
+      rangeEnd = inputRecord[0];
+      count ++;
+    } else if (count % batchSize != 0) {
+      rangeEnd = inputRecord[0];
+      count ++;
+    } else {
+      Iterable<JsonObject> output = outputIterable(batchSize);
+      rangeStart = inputRecord[0];
+      rangeEnd = inputRecord[0];
+      count = 1;
+      return output;
+    }
+
+    return new EmptyIterable<>();
+  }
+
+  /**
+   * Output a single record iterable when the size of the normalized array has reached the threshold
+   * and empty iterable otherwise.
+   * @param threshold the threshold to output
+   * @return iterable of JsonObject
+   */
+  private Iterable<JsonObject> outputIterable(long threshold) {
+    if (count >= threshold) {
+      return new SingleRecordIterable<>(buildRangeRecord());
+    } else {
+      return new EmptyIterable<>();
+    }
+  }
+
+  /**
+   * Build a final range record
+   * @return the range record
+   */
+  private JsonObject buildRangeRecord() {
+    JsonObject newRecord = new JsonObject();
+    newRecord.addProperty(columnStart, rangeStart);
+    newRecord.addProperty(columnEnd, rangeEnd);
+    return newRecord;
+  }
+}

--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/CsvExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/CsvExtractor.java
@@ -60,6 +60,7 @@ import static com.linkedin.cdi.configuration.StaticConstants.*;
 public class CsvExtractor extends MultistageExtractor<String, String[]> {
   private static final Logger LOG = LoggerFactory.getLogger(CsvExtractor.class);
   private final static Long SCHEMA_INFER_MAX_SAMPLE_SIZE = 100L;
+  final private static String[] EOF = KEY_WORD_EOF.split(KEY_WORD_COMMA);
   private CsvExtractorKeys csvExtractorKeys = new CsvExtractorKeys();
 
   public CsvExtractorKeys getCsvExtractorKeys() {
@@ -164,6 +165,11 @@ public class CsvExtractor extends MultistageExtractor<String, String[]> {
       if (hasNextPage() && processInputStream(csvExtractorKeys.getProcessedCount())) {
         return readRecord(reuse);
       }
+    }
+
+    if (!this.eof && extractorKeys.getExplictEof()) {
+      eof = true;
+      return EOF;
     }
     return (String[]) endProcessingAndValidateCount();
   }


### PR DESCRIPTION
Generating ranges for partitioned data ingestion is a common need. While normally we can generate ranges from source API through queries, the performance might not always be great. 

The range generator can ease that process. The generated ranges can be used as secondary input in the subsequent job to control the data ranges to extract. 

This approach can often lead to better performance than using time partitions. 