### PR TITLE
Enable reading multiple files in HDFS connection without using a list…

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/converter/InFlowValidationConverter.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/converter/InFlowValidationConverter.java
@@ -148,7 +148,8 @@ public class InFlowValidationConverter extends Converter<Schema, Schema, Generic
       } else {
         rowCount.addAndGet(records.size());
       }
-    }    return rowCount.get();
+    }
+    return rowCount.get();
   }
 
   private void updateFailureCount(GenericRecord record) {

--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/AvroExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/AvroExtractor.java
@@ -147,6 +147,11 @@ public class AvroExtractor extends MultistageExtractor<Schema, GenericRecord> {
         row = avroSchemaBasedFilter.filter(row);
       }
       return addDerivedFields(row);
+    } else {
+      connection.closeStream();
+      if (hasNextPage() && processInputStream(avroExtractorKeys.getProcessedCount())) {
+        return readRecord(reuse);
+      }
     }
 
     if (!this.eof && extractorKeys.getExplictEof()) {


### PR DESCRIPTION
Previously, when read files from HdfsSource, we can either read a file list or read a single file. When there are multiple files, we require a list file be generated, and then use the list file to drive the next stage that reads individual files. 

However, we have situation that require DIL read all files under a certain directory without using list files. For example, in in-flow validation, if we use a list file, the validation will happen in each work unit, and thus cannot validate the total row counts. 

With this change, when there are multiple files found in location that is provided through ms.source.uri, the HdfsConnection will paginate through the files, and read each file as a page.  

However, when ms.source.uri has a URI parameter "RE", then it will still generate a list as usual. 