### PR TITLE
Add a validation cateogry to secondary input

### DIFF
--- a/cdi-core/build.gradle
+++ b/cdi-core/build.gradle
@@ -61,7 +61,10 @@ dependencies {
   compile externalDependency.'testng'
   compile externalDependency.'jhyde'
   compile externalDependency.'li-apache-kafka-clients'
-  compile externalDependency.'opencsv'
+  //compile externalDependency.'opencsv'
+  implementation(externalDependency.'opencsv') {
+    force = true
+  }
 
   runtime externalDependency.'gobblin-azkaban'
   runtime externalDependency.'gobblin-kafka-08'

--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/StaticConstants.java
@@ -64,6 +64,7 @@ public interface StaticConstants {
   String KEY_WORD_TYPE = "type";
   String KEY_WORD_UNITS = "units";
   String KEY_WORD_UNKNOWN = "unknown";
+  String KEY_WORD_VALIDATION = "validation";
   String KEY_WORD_VALUES = "values";
   String KEY_WORD_THRESHOLD = "threshold";
   String KEY_WORD_CRITERIA = "criteria";

--- a/cdi-core/src/main/java/com/linkedin/cdi/connection/HdfsConnection.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/connection/HdfsConnection.java
@@ -59,19 +59,23 @@ public class HdfsConnection extends MultistageConnection {
   }
 
   /**
-   * Get a list of files if the URI has pattern match, else read the file at the URI.
+   * Get a list of files if the URI has pattern match, else read the files at the URI.
    *
    * In order to perform a list operation and output the list of files, the
    * ms.source.uri need to coded like /directory?RE=file-name-pattern. If the purpose
    * is to list all files, the file name pattern can be just ".*".
    *
-   * In order to perform a read of a file and output the content of the file as
-   * InputStream. ms.source.uri need to be full path without RE expression. If a
-   * partial path is given, then only a single file will be picked because there
-   * will be a list command performed before the read. A partial path could result
-   * in multiple files being listed, but then only the first file will be used.
+   * In order to perform a read of files and output the content of the file as
+   * InputStream, ms.source.uri need to be a path without RE expression.
    *
-   * So if the intention is to read a single file, support the full path to ms.source.uri.
+   * If a partial path is given without RE expression, there will be a list command performed before the read.
+   * The list of files will be processed through the pagination process, i.e., each
+   * file is read as a page. In such case ms.pagination has to be set so that pagination
+   * can take effect. If pagination is not enabled, then only the first file will
+   * be read.
+   *
+   * If the intention is to read a single file, support the full path to ms.source.uri without
+   * the RE expression.
    *
    * @param status prior work unit status
    * @return new work unit status

--- a/cdi-core/src/main/java/com/linkedin/cdi/converter/InFlowValidationConverter.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/converter/InFlowValidationConverter.java
@@ -12,7 +12,7 @@ import com.linkedin.cdi.util.HdfsReader;
 import com.linkedin.cdi.util.JsonUtils;
 import java.text.DecimalFormat;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -49,15 +49,17 @@ import static com.linkedin.cdi.configuration.StaticConstants.*;
  */
 public class InFlowValidationConverter extends Converter<Schema, Schema, GenericRecord, GenericRecord> {
   private static final Logger LOG = LoggerFactory.getLogger(InFlowValidationConverter.class);
-  int expectedRecordsCount;
-  int actualRecordsCount;
+  long expectedRecordsCount;
+  long actualRecordsCount;
   private String field;
   private int threshold;
   private String criteria;
   private String errorColumn;
+  private WorkUnitState workUnitState;
 
   @Override
   public Converter<Schema, Schema, GenericRecord, GenericRecord> init(WorkUnitState workUnitState) {
+    this.workUnitState = workUnitState;
     //Load the input to memory
     expectedRecordsCount = getBaseRowCount(workUnitState);
     fillValidationAttributes(workUnitState);
@@ -110,41 +112,60 @@ public class InFlowValidationConverter extends Converter<Schema, Schema, Generic
   }
 
   /**
-   * Extract records from secondary input and store the expected record count.
-   * If field is configured in the secondary input and field column
-   *  is of type array expected record count with array size
-   *  else use all the input records as expected size
+   * Extract records from secondary input and store the base count for comparison. Base
+   * count is the expected value.
+   *
+   * If field is configured in the secondary input:
+   *   - if field column is of type array, then base count counts array size
+   *   - if field column is of type numeric, the base count adds the numeric value
+   *
+   * else the base count counts simply the number of rows, this includes:
+   *   - field column is not numeric nor array
+   *   - field column is defined but not exists in the secondary input
+   *   - field column is not defined at all
+   *
    * @param workUnitState the work unit state object containing secondary input parameter
    * @return the expected row count
    */
-  private int getBaseRowCount(WorkUnitState workUnitState) {
-    JsonArray payloads = JsonUtils.filter(KEY_WORD_CATEGORY, KEY_WORD_PAYLOAD,
+  private long getBaseRowCount(WorkUnitState workUnitState) {
+    JsonArray validations = JsonUtils.filter(KEY_WORD_CATEGORY, KEY_WORD_VALIDATION,
         MSTAGE_SECONDARY_INPUT.get(workUnitState));
 
     // by default, we expect 1 record
-    if (payloads.size() == 0) {
+    if (validations.isJsonNull() || validations.size() == 0) {
       return 1;
     }
 
     // secondary input can have multiple payload entries, and each can configure a "fields" element
     // but for validation purpose, only the first payload entry, and the first field is used.
-    JsonElement fields = JsonUtils.get(KEY_WORD_FIELDS, payloads.get(0).getAsJsonObject());
+    JsonElement fields = JsonUtils.get(KEY_WORD_FIELDS, validations.get(0).getAsJsonObject());
     field = StringUtils.EMPTY;
     if (fields.isJsonArray() && fields.getAsJsonArray().size() > 0) {
       field = fields.getAsJsonArray().get(0).getAsString();
     }
 
-    AtomicInteger rowCount = new AtomicInteger();
-    for (JsonElement entry : payloads) {
+    AtomicLong rowCount = new AtomicLong();
+
+    for (JsonElement entry : validations) {
       JsonObject entryJson = entry.getAsJsonObject();
       JsonArray records = new JsonArray();
       records.addAll(new HdfsReader(workUnitState).readSecondary(entryJson));
 
       // No of expected records
-      if (records.size() > 0
-          && StringUtils.isNotBlank(field)
-          && (records.get(0).getAsJsonObject().get(field) instanceof JsonArray)) {
-        records.forEach(record -> rowCount.addAndGet(record.getAsJsonObject().get(field).getAsJsonArray().size()));
+      if (records.size() > 0  && StringUtils.isNotBlank(field)) {
+        JsonElement sample = JsonUtils.get(field, records.get(0).getAsJsonObject());
+        if (sample.isJsonArray()) {
+          records.forEach(record -> rowCount.addAndGet(record.getAsJsonObject().get(field).getAsJsonArray().size()));
+        } else if (sample.isJsonPrimitive()) {
+          try {
+            records.forEach(record -> rowCount.addAndGet(record.getAsJsonObject().get(field).getAsLong()));
+          } catch (Exception e) {
+            LOG.info("Secondary field is not a long value.");
+            rowCount.addAndGet(records.size());
+          }
+        } else {
+          rowCount.addAndGet(records.size());
+        }
       } else {
         rowCount.addAndGet(records.size());
       }
@@ -166,12 +187,14 @@ public class InFlowValidationConverter extends Converter<Schema, Schema, Generic
     float actualPercentage = ((float) actualRecordsCount / expectedRecordsCount) * 100;
     LOG.info("base row count: {}, actual row count: {}", expectedRecordsCount, actualRecordsCount);
 
-    boolean failJob = criteria.equalsIgnoreCase(KEY_WORD_FAIL) && actualPercentage >= threshold
-        || criteria.equalsIgnoreCase(KEY_WORD_SUCCESS) && actualPercentage < threshold;
-
-    if (failJob) {
+    if (criteria.equalsIgnoreCase(KEY_WORD_FAIL) && actualPercentage >= threshold) {
       // Fail the validation by throwing runtime exception
-      throw new RuntimeException("Failure Threshold exceeds more than " + threshold + "%");
+      workUnitState.setWorkingState(WorkUnitState.WorkingState.FAILED);
+      throw new RuntimeException("Failure rate exceeds threshold (" + threshold + "%).");
+    } else if (criteria.equalsIgnoreCase(KEY_WORD_SUCCESS) && actualPercentage < threshold) {
+      // Fail the validation by throwing runtime exception
+      workUnitState.setWorkingState(WorkUnitState.WorkingState.FAILED);
+      throw new RuntimeException("Success rate is lower than threshold (" + threshold + "%).");
     } else {
       LOG.info("Validation passed with {} rate {}% {} {}%",
           criteria.equalsIgnoreCase(KEY_WORD_FAIL) ? "failure" : "success",

--- a/cdi-core/src/main/java/com/linkedin/cdi/source/MultistageSource.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/source/MultistageSource.java
@@ -175,13 +175,13 @@ public class MultistageSource<S, D> extends AbstractSource<S, D> {
         wu.setProp(MSTAGE_ACTIVATION_PROPERTY.toString(),
             getUpdatedWorkUnitActivation(wu, authentications.get(0).getAsJsonObject()));
       }
-        // unlike activation secondary inputs, payloads will be processed in each work unit
-        // and payloads will not be loaded until the Connection executes the command
-        wu.setProp(MSTAGE_PAYLOAD_PROPERTY.toString(), payloads);
+      // unlike activation secondary inputs, payloads will be processed in each work unit
+      // and payloads will not be loaded until the Connection executes the command
+      wu.setProp(MSTAGE_PAYLOAD_PROPERTY.toString(), payloads);
     }
 
     if (eventReporter != null) {
-      // Send workunit creation event
+      // Send work unit creation event
       eventReporter.send(EventHelper.createWorkunitCreationEvent(state,wuList,getClass().getName()));
     }
     return wuList;

--- a/cdi-core/src/test/java/com/linkedin/cdi/source/SimpleIntegrationTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/source/SimpleIntegrationTest.java
@@ -14,8 +14,17 @@ public class SimpleIntegrationTest {
   @Test(enabled = false)
   void fileDumpJobTask() throws Exception {
     Logger.getRootLogger().setLevel(Level.INFO);
-    EmbeddedGobblin job = new EmbeddedGobblin("SimpleIntegrationTest Job");
+    EmbeddedGobblin job = new EmbeddedGobblin("SimpleIntegrationTestJob");
     Assert.assertTrue(job.jobFile(getClass().getResource("/pull/metrics_integration_test.pull").getPath())
+        .run()
+        .isSuccessful());
+  }
+
+  @Test(enabled = false)
+  void httpIntegrationTask() throws Exception {
+    Logger.getRootLogger().setLevel(Level.INFO);
+    EmbeddedGobblin job = new EmbeddedGobblin("IMDB_Ratings_ingestion");
+    Assert.assertTrue(job.jobFile(getClass().getResource("/pull/imdb-example.pull").getPath())
         .run()
         .isSuccessful());
   }

--- a/cdi-core/src/test/resources/pull/imdb-example.pull
+++ b/cdi-core/src/test/resources/pull/imdb-example.pull
@@ -1,0 +1,35 @@
+# This job uses IMDB public dataset available at https://www.imdb.com/interfaces/
+
+source.class=com.linkedin.cdi.source.HttpSource
+ms.extract.preprocessors=com.linkedin.cdi.preprocessor.GunzipProcessor
+ms.extractor.class=com.linkedin.cdi.extractor.CsvExtractor
+converter.classes=org.apache.gobblin.converter.csv.CsvToJsonConverterV2,org.apache.gobblin.converter.avro.JsonIntermediateToAvroConverter
+ms.http.client.factory=com.linkedin.cdi.factory.DefaultConnectionClientFactory
+
+dataset.urn=com.cdi.example.imdb.ratings
+extract.namespace=imdb
+extract.table.name=title_ratings
+extract.table.type=SNAPSHOT_ONLY
+extract.is.full=true
+job.name=ImdbTitleRatings
+
+ms.output.schema=[{"columnName":"tconst","isNullable":"true","dataType":{"type":"string"}},{"columnName":"averageRating","isNullable":"true","dataType":{"type":"string"}},{"columnName":"numVotes","isNullable":"true","dataType":{"type":"string"}}]
+ms.source.uri=https://datasets.imdbws.com/title.ratings.tsv.gz
+
+ms.csv={"columnHeaderIndex": 0, "fieldSeparator": "u0009"}
+ms.http.statuses={"success": [200, 201, 202], "warning": [404]}
+ms.http.request.method=GET
+
+ms.http.response.type={"Content-Type":"binary/octet-stream"}
+
+fs.uri=file://localhost/
+state.store.fs.uri=file://localhost/
+data.publisher.final.dir=/tmp/gobblin/job-output
+
+writer.destination.type=HDFS
+writer.output.format=AVRO
+
+taskexecutor.threadpool.size=1
+workunit.retry.enabled=false
+task.maxretries=0
+Xmx=1G


### PR DESCRIPTION
We used to use payload to include secondary inputs for validation purpose. The secondary input sets the expected values (rows) for comparison. But the "payload" type gets in conflict with egress, as payload was designed for egress. Although egress works for HTTP for now, using the "payload" type for validation limits certain types of validation. For example, if the expected rows is just a number in a file, instead of a list, the HDFS pagination doesn't work as expected. 

This PR creates a new category in secondary input called "validation". It is used in IFV (InFlowValidationConverter) only for now. In the future, other validations can also use this category. 

Generally, a validation secondary input includes files that can establish a base (expected) value for comparison (validation). Currently the comparison is limited to row count comparison only. 