### PR TITLE
Allow validation job to retry

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/connection/HdfsConnection.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/connection/HdfsConnection.java
@@ -123,6 +123,7 @@ public class HdfsConnection extends MultistageConnection {
    */
   @Override
   public boolean closeAll(String message) {
+    fileListIterator = null;
     try {
       fsHelper.close();
       fsHelper = null;

--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/MultistageExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/MultistageExtractor.java
@@ -212,6 +212,10 @@ public class MultistageExtractor<S, D> implements Extractor<S, D> {
     if (connection != null) {
       connection.closeAll(StringUtils.EMPTY);
     }
+
+    // reset counters for retrying
+    extractorKeys.setProcessedCount(0);
+    workUnitStatus = WorkUnitStatus.builder().build();
   }
 
   /**


### PR DESCRIPTION
In retrying, Gobblin reuse the extractor object, that leads to wrong counters including pagination values. This change reset the counters at the end of extractor execution (close()). This change is required for errors in converters  or error in the middle of connection; in those situations, because the process has started, and counters has accumulated values, without reseting, those counters will be wrong. 

Counters reset include:
- rows-processed
- pagination current page number and offset 