### PR TITLE
Move preprocessing from sub-classes to MultistageExtractor

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/CsvExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/CsvExtractor.java
@@ -17,8 +17,6 @@ import com.linkedin.cdi.filter.CsvSchemaBasedFilter;
 import com.linkedin.cdi.keys.CsvExtractorKeys;
 import com.linkedin.cdi.keys.ExtractorKeys;
 import com.linkedin.cdi.keys.JobKeys;
-import com.linkedin.cdi.preprocessor.InputStreamProcessor;
-import com.linkedin.cdi.preprocessor.StreamProcessor;
 import com.linkedin.cdi.util.JsonIntermediateSchema;
 import com.linkedin.cdi.util.SchemaBuilder;
 import com.linkedin.cdi.util.SchemaUtils;
@@ -203,12 +201,6 @@ public class CsvExtractor extends MultistageExtractor<String, String[]> {
     if (workUnitStatus.getBuffer() != null) {
       try {
         InputStream input = workUnitStatus.getBuffer();
-        for (StreamProcessor<?> transformer : extractorKeys.getPreprocessors()) {
-          if (transformer instanceof InputStreamProcessor) {
-            input = ((InputStreamProcessor) transformer).process(input);
-          }
-        }
-
         CSVParser parser = new CSVParserBuilder().withSeparator(MSTAGE_CSV.getFieldSeparator(state).charAt(0))
             .withQuoteChar(MSTAGE_CSV.getQuoteCharacter(state).charAt(0))
             .withEscapeChar(MSTAGE_CSV.getEscapeCharacter(state).charAt(0))

--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/FileDumpExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/FileDumpExtractor.java
@@ -12,7 +12,6 @@ import com.google.gson.JsonObject;
 import com.linkedin.cdi.keys.ExtractorKeys;
 import com.linkedin.cdi.keys.FileDumpExtractorKeys;
 import com.linkedin.cdi.keys.JobKeys;
-import com.linkedin.cdi.preprocessor.InputStreamProcessor;
 import com.linkedin.cdi.preprocessor.OutputStreamProcessor;
 import com.linkedin.cdi.preprocessor.StreamProcessor;
 import com.linkedin.cdi.util.ParameterTypes;
@@ -143,15 +142,7 @@ public class FileDumpExtractor extends MultistageExtractor<String, String> {
     }
 
     try {
-
-      // apply preprocessors
       InputStream input = workUnitStatus.getBuffer();
-      for (StreamProcessor<?> transformer : extractorKeys.getPreprocessors()) {
-        if (transformer instanceof InputStreamProcessor) {
-          input = ((InputStreamProcessor) transformer).process(input);
-        }
-      }
-
       String fileName = fileDumpExtractorKeys.getFileDumpLocation() + "/"
           + fileDumpExtractorKeys.getFileName();
       if (jobKeys.isPaginationEnabled()) {

--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/TextExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/TextExtractor.java
@@ -15,8 +15,6 @@ import com.linkedin.cdi.configuration.StaticConstants;
 import com.linkedin.cdi.keys.ExtractorKeys;
 import com.linkedin.cdi.keys.JobKeys;
 import com.linkedin.cdi.keys.JsonExtractorKeys;
-import com.linkedin.cdi.preprocessor.InputStreamProcessor;
-import com.linkedin.cdi.preprocessor.StreamProcessor;
 import com.linkedin.cdi.util.JsonUtils;
 import java.io.IOException;
 import java.io.InputStream;
@@ -105,13 +103,7 @@ public class TextExtractor extends MultistageExtractor<JsonArray, JsonObject> {
         return null;
       } else {
         try {
-          // apply preprocessors
           InputStream input = workUnitStatus.getBuffer();
-          for (StreamProcessor<?> transformer : extractorKeys.getPreprocessors()) {
-            if (transformer instanceof InputStreamProcessor) {
-              input = ((InputStreamProcessor) transformer).process(input);
-            }
-          }
           writeToStringBuffer(input, output);
           input.close();
           JsonObject jsonObject = new JsonObject();


### PR DESCRIPTION
InputStream preprocessors can be applied commonly to all types of extractor. Previously, as we added extractors one by one, this code is duplicated to some extractors, and missed others. This change move that part of function to the base class so that all extractors can support preprocessors. 

The previously supported extractors are Csv, Text, and FileDump. The previously missed extractors are Json and Avro. 

The change is tested with regression test suite and verified with a new use case that it supports also JSON. 