### PR TITLE
update ms.work.unit.parallelism.max to enable unlimited number of work units

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/configuration/PropertyCollection.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/configuration/PropertyCollection.java
@@ -247,12 +247,19 @@ public interface PropertyCollection {
     }
   };
 
-  // default: 100, minimum: 0, maximum: 1000, 0 = default value
-  IntegerProperties MSTAGE_WORK_UNIT_PARALLELISM_MAX = new IntegerProperties("ms.work.unit.parallelism.max", 500, 5000, 0) {
+  // default: 100, minimum: -1, maximum: 1000, 0 = default value, -1 = max int
+  IntegerProperties MSTAGE_WORK_UNIT_PARALLELISM_MAX = new IntegerProperties("ms.work.unit.parallelism.max", 500, 5000, -1) {
     @Override
     protected Integer getValidNonblankWithDefault(State state) {
       int value = super.getValidNonblankWithDefault(state);
-      return value == 0 ? getDefaultValue() : value;
+      switch (value) {
+        case 0:
+          return getDefaultValue();
+        case -1:
+          return Integer.MAX_VALUE;
+        default:
+          return value;
+      }
     }
   };
 

--- a/docs/parameters/ms.work.unit.parallelism.max.md
+++ b/docs/parameters/ms.work.unit.parallelism.max.md
@@ -60,7 +60,8 @@ Therefore, unless there are 100s or more work units for a job, it is not necessa
 to set `ms.work.unit.parallelism.max`, or it can be set to 0 (default), which means the default value mentioned above.
 
 If you don't want to impose a limit on the maximum number of work units, please set `ms.work.unit.parallelism.max`
-to -1. In this case, the limit will be set to 2147483647 (i.e., Integer.MAX_VALUE)
+to -1. In this case, the limit will be set to 2147483647 (i.e., Integer.MAX_VALUE). Please note that this value is to be
+used by advanced users only as there is a chance of JVM going out of memory while creating the work units.
 
 If ms.work.unit.parallelism.max is set to any value greater than or equal to 0, and there are 
 more work units than ms.work.unit.parallelism.max, then the Gobblin job need to 

--- a/docs/parameters/ms.work.unit.parallelism.max.md
+++ b/docs/parameters/ms.work.unit.parallelism.max.md
@@ -57,9 +57,12 @@ will be processed in 1 job execution. In such case, the task executors will
 recursively process work units the same way based on thread pool size.
 
 Therefore, unless there are 100s or more work units for a job, it is not necessary 
-to set `ms.work.unit.parallelism.max`, or it can be set to 0 (default), which means no limit.
+to set `ms.work.unit.parallelism.max`, or it can be set to 0 (default), which means the default value mentioned above.
 
-If ms.work.unit.parallelism.max is set to any value greater than 0, and there are 
+If you don't want to impose a limit on the maximum number of work units, please set `ms.work.unit.parallelism.max`
+to -1. In this case, the limit will be set to 2147483647 (i.e., Integer.MAX_VALUE)
+
+If ms.work.unit.parallelism.max is set to any value greater than or equal to 0, and there are 
 more work units than ms.work.unit.parallelism.max, then the Gobblin job need to 
 be executed repeatedly until all work units are processed.
 


### PR DESCRIPTION
…k units

Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [JIRA](https://jira01.corp.linkedin.com:8443/issues) issues and references them in the PR title. 

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Enable unlimited number of work units by setting ms.work.unit.parallelism.max to -1. Previous configuration won't be affected

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

