### PR TITLE
Add initial value for session key

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/MultistageExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/MultistageExtractor.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -839,6 +840,7 @@ public class MultistageExtractor<S, D> implements Extractor<S, D> {
    * Initial work unit variable values include
    * - watermarks defined for each work unit
    * - initial pagination defined at the source level
+   * - initial session key values.
    *
    * @return work unit specific initial parameters for the first request to source
    */
@@ -849,6 +851,14 @@ public class MultistageExtractor<S, D> implements Extractor<S, D> {
     for (Map.Entry<ParameterTypes, Long> entry : jobKeys.getPaginationInitValues().entrySet()) {
       variableValues.addProperty(entry.getKey().toString(), entry.getValue());
     }
+
+    JsonObject sessionKeyField = jobKeys.getSessionKeyField();
+    if (Objects.nonNull(sessionKeyField)) {
+      if (sessionKeyField.has("initValue")) {
+        variableValues.addProperty(ParameterTypes.SESSION.toString(), sessionKeyField.get("initValue").toString());
+      }
+    }
+
     return variableValues;
   }
 


### PR DESCRIPTION
Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
https://jira01.corp.linkedin.com:8443/browse/ORBIT-43086

### Description
This PR allows initial values for session keys, such as for cursor pagination. This is specifically useful for when we need to do cursor pagination by passing in cursor values in the URI of a POST/PUT request. Currently, for a POST/PUT DIL passes all parameters defined in ms.parameters to the request body. However, for our use case, this will not work as the session key is needed in the URI. To solve this we can reference the session variable in the URI using {{<variable>}}. In order for this to work however, an initial value must be provided as the {{<variable>}} will not get substituted if there is not initial value


### Tests
Tested with Gobblin in Azkaban https://ltx1-holdemaz05.grid.linkedin.com:8443/executor?execid=71241500#jobslist. Works as expected. 

