### PR TITLE
Today, all GET URL parameters are URL encoded in DIL.

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/factory/http/HttpRequestMethod.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/factory/http/HttpRequestMethod.java
@@ -55,6 +55,27 @@ import org.slf4j.LoggerFactory;
  */
 
 public enum HttpRequestMethod {
+  /**
+   * Note: This works when the URI template has all the variable parameters.
+   * If there are any additional parameters, then URIBuilder encodes all parameters while building.
+   */
+  GET_XE("GET_XE") {
+    @Override
+    protected HttpUriRequest getHttpRequestContentJson(String uriTemplate,
+        JsonObject parameters, JsonObject payloads)
+        throws UnsupportedEncodingException {
+      Pair<String, JsonObject> replaced = VariableUtils.replaceWithTracking(uriTemplate, parameters, false);
+      //ignore payloads
+      return new HttpGet(appendParameters(replaced.getKey(), replaced.getValue()));
+    }
+
+    @Override
+    protected HttpUriRequest getHttpRequestContentUrlEncoded(String uriTemplate, JsonObject parameters)
+        throws UnsupportedEncodingException {
+      return getHttpRequestContentJson(uriTemplate, parameters, new JsonObject());
+    }
+  },
+
   GET("GET") {
     @Override
     protected HttpUriRequest getHttpRequestContentJson(String uriTemplate,

--- a/cdi-core/src/test/java/com/linkedin/cdi/util/HttpRequestMethodTest.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/util/HttpRequestMethodTest.java
@@ -48,6 +48,8 @@ public class HttpRequestMethodTest extends PowerMockTestCase {
   final static String CONTENT_TYPE = "Content-Type";
   final static String CONTENT_TYPE_VALUE = "application/x-www-form-urlencoded";
   final static String BASE_URI = "https://domain/%s/calls";
+  final static String BASE_URI_WITH_ONLYFROM_PARAMS = "https://domain/%s/calls?fdt=%s";
+  final static String BASE_URI_WITH_TOANDFROM_PARAMS = "https://domain/%s/calls?fdt=%s&tdt=%s";
   private static Gson gson = new Gson();
   private Map<String, String> headers;
   private String expected;
@@ -65,6 +67,54 @@ public class HttpRequestMethodTest extends PowerMockTestCase {
   @BeforeMethod
   public void setUp() {
     headers = new HashMap<>();
+  }
+
+  /**
+   * Test HttpGet_xe method with parameters
+   * Note: This works when the URI template has all the variable parameters.
+   * If there are any additional parameters, then URIBuilder encodes all parameters while building.
+   *
+   * @throws UnsupportedEncodingException
+   */
+  /*
+  @Test
+  public void testGetXeHttpGetRequest1() throws UnsupportedEncodingException {
+    expected = String.format(
+        "%s %s %s",
+        "GET",
+        String.format(BASE_URI_WITH_TOANDFROM_PARAMS, VERSION_2, FROM_DATETIME, URLEncoder.encode(TO_DATETIME, StandardCharsets.UTF_8.toString())),
+        HTTP_POST_FIX);
+    parameters = generateParameterString(FROM_DATETIME, TO_DATETIME, VERSION_2);
+    String uriTemplate = String.format(BASE_URI_WITH_ONLYFROM_PARAMS, "{{version}}", "{{fromDateTime}}");
+
+    HttpUriRequest getRequest =
+        HttpRequestMethod.GET_XE.getHttpRequest(
+            uriTemplate, parameters, headers);
+    Assert.assertEquals(getRequest.toString(), expected);
+
+    addContentType();
+    getRequest = HttpRequestMethod.GET_XE.getHttpRequest(uriTemplate, parameters, headers);
+    Assert.assertEquals(getRequest.toString(), expected);
+  }
+  */
+  @Test
+  public void testGetXeHttpGetRequest() throws UnsupportedEncodingException {
+    expected = String.format(
+        "%s %s %s",
+        "GET",
+        String.format(BASE_URI_WITH_TOANDFROM_PARAMS, VERSION_2, FROM_DATETIME, TO_DATETIME),
+        HTTP_POST_FIX);
+    parameters = generateParameterString(FROM_DATETIME, TO_DATETIME, VERSION_2);
+    String uriTemplate = String.format(BASE_URI_WITH_TOANDFROM_PARAMS, "{{version}}", "{{fromDateTime}}", "{{toDateTime}}");
+
+    HttpUriRequest getRequest =
+        HttpRequestMethod.GET_XE.getHttpRequest(
+            uriTemplate, parameters, headers);
+    Assert.assertEquals(getRequest.toString(), expected);
+
+    addContentType();
+    getRequest = HttpRequestMethod.GET_XE.getHttpRequest(uriTemplate, parameters, headers);
+    Assert.assertEquals(getRequest.toString(), expected);
   }
 
   /**


### PR DESCRIPTION
https://github.com/linkedin/data-integration-library/blob/master/docs/parameters/ms.http.request.method.md

This change adds a new GET_XE ms.http.request method which will not encode URL parameters. This is a hidden feature. That's why no update to documentation.

Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [JIRA](https://jira01.corp.linkedin.com:8443/issues) issues and references them in the PR title. 

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

