### PR TITLE
Added support for '.' in Bucket Name

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/source/S3SourceV2.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/source/S3SourceV2.java
@@ -92,11 +92,11 @@ public class S3SourceV2 extends MultistageSource<Schema, GenericRecord> {
     }
 
     // separate the endpoint, which should be a URL without bucket name, from the domain name
-    s3SourceV2Keys.setEndpoint("https://" + getEndpointFromHost(url.getHost()));
+    s3SourceV2Keys.setEndpoint("https://" + getEndpoint(parameters, url.getHost()));
     s3SourceV2Keys.setPrefix(url.getPath().substring(1));
 
     // separate the bucket name from URI domain name
-    s3SourceV2Keys.setBucket(url.getHost().split("\\.")[0]);
+    s3SourceV2Keys.setBucket(getBucketName(parameters, url.getHost()));
 
     s3SourceV2Keys.setFilesPattern(MSTAGE_SOURCE_FILES_PATTERN.get(state));
     s3SourceV2Keys.setMaxKeys(MSTAGE_S3_LIST_MAX_KEYS.get(state));

--- a/cdi-core/src/main/java/com/linkedin/cdi/source/S3SourceV2.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/source/S3SourceV2.java
@@ -154,7 +154,8 @@ public class S3SourceV2 extends MultistageSource<Schema, GenericRecord> {
    *
    * @param parameters JsonObject containing ms.source.s3.parameters
    * @param host hostname with bucket name in the beginning
-   * @return the endpoint name without the bucket name
+   * @return the endpoint name if bucket name is present in the parameters then removes the bucket name from host and
+   * calls the getEndpointFromHost method to get the endpoint.
    */
   @VisibleForTesting
   protected String getEndpoint(JsonObject parameters, String host) {

--- a/cdi-core/src/test/java/com/linkedin/cdi/source/S3SourceV2Test.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/source/S3SourceV2Test.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.cdi.source;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.io.UnsupportedEncodingException;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -35,5 +36,46 @@ public class S3SourceV2Test {
     Assert.assertEquals(source.getS3SourceV2Keys().getPrefix(), "crawl-data/CC-MAIN-2019-43/cc-index.paths.gz");
     Assert.assertEquals(source.getS3SourceV2Keys().getMaxKeys(), new Integer(1000));
     Assert.assertEquals(source.getS3SourceV2Keys().getConnectionTimeout(), new Integer(30));
+  }
+
+  @Test
+  public void testBucketName() {
+    S3SourceV2 s3SourceV2 = new S3SourceV2();
+    JsonObject parameteres =
+        new Gson().fromJson("{\"region\" : \"us-east-2\", \"bucket_name\" : \"collect-us-west-2.tealium.com\"}",
+            JsonObject.class);
+    String host = "collect-us-west-2.tealium.com.s3.amazonaws.com";
+    String bucketName = s3SourceV2.getBucketName(parameteres, host);
+    Assert.assertEquals(bucketName, "collect-us-west-2.tealium.com");
+  }
+
+  @Test
+  public void testBucketNameWithoutBucketParameter() {
+    S3SourceV2 s3SourceV2 = new S3SourceV2();
+    JsonObject parameteres = new Gson().fromJson("{\"region\" : \"us-east-2\"}", JsonObject.class);
+    String host = "collect-us-west-2.s3.amazonaws.com";
+    String bucketName = s3SourceV2.getBucketName(parameteres, host);
+    Assert.assertEquals(bucketName, "collect-us-west-2");
+  }
+
+  @Test
+  public void testEndpoint() {
+    S3SourceV2 s3SourceV2 = new S3SourceV2();
+    JsonObject parameteres =
+        new Gson().fromJson("{\"region\" : \"us-east-2\", \"bucket_name\" : \"colleCt-us-west-2.tealium.com\"}",
+            JsonObject.class);
+    String host = "collect-us-west-2.tealium.com.s3.amazonaws.com";
+    String endpoint = s3SourceV2.getEndpoint(parameteres, host);
+    Assert.assertEquals(endpoint, "s3.amazonaws.com");
+  }
+
+  @Test
+  public void testEndpointWithoutPeriod() {
+    S3SourceV2 s3SourceV2 = new S3SourceV2();
+    JsonObject parameteres =
+        new Gson().fromJson("{\"region\" : \"us-east-2\", \"bucket_name\" : \"collect-us-west-2\"}", JsonObject.class);
+    String host = "collect-us-west-2.s3.amazonaws.com";
+    String endpoint = s3SourceV2.getEndpoint(parameteres, host);
+    Assert.assertEquals(endpoint, "s3.amazonaws.com");
   }
 }

--- a/cdi-core/src/test/java/com/linkedin/cdi/source/S3SourceV2Test.java
+++ b/cdi-core/src/test/java/com/linkedin/cdi/source/S3SourceV2Test.java
@@ -72,10 +72,10 @@ public class S3SourceV2Test {
   @Test
   public void testEndpointWithoutPeriod() {
     S3SourceV2 s3SourceV2 = new S3SourceV2();
-    JsonObject parameteres =
+    JsonObject parameters =
         new Gson().fromJson("{\"region\" : \"us-east-2\", \"bucket_name\" : \"collect-us-west-2\"}", JsonObject.class);
     String host = "collect-us-west-2.s3.amazonaws.com";
-    String endpoint = s3SourceV2.getEndpoint(parameteres, host);
+    String endpoint = s3SourceV2.getEndpoint(parameters, host);
     Assert.assertEquals(endpoint, "s3.amazonaws.com");
   }
 }

--- a/docs/parameters/ms.source.s3.parameters.md
+++ b/docs/parameters/ms.source.s3.parameters.md
@@ -23,6 +23,7 @@ It can have the following attributes:
 - **write_timeout_seconds**: integer, write time out in seconds
 - **connection_timeout_seconds**: Sets the socket to timeout after failing to establish a connection with the server after milliseconds.
 - **connection_max_idle_millis**:  Sets the socket to timeout after timeout milliseconds of inactivity on the socket.
+- **bucket_name**:  Sets the bucket name, optional if the bucket name doesn't contain any special characters.
    
 ### Example
 


### PR DESCRIPTION
Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [JIRA](https://jira01.corp.linkedin.com:8443/issues) issues and references them in the PR title. 

### Description
- [x] Here are some details about my PR, including screenshots (if applicable): Currently for the separation of bucket name and endpoint for s3 uploads we rely on '.' present in the host url. The left side of '.' is considered as bucket name and right side of it is considered an endpoint.
So added a new parameter in ms.source.s3.parameters for bucket name as "bucket_name" which would help to navigate through the edge cases. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Added UTs for it.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

