### PR TITLE
Adding support for secondary input decryption 

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/util/HdfsReader.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/util/HdfsReader.java
@@ -211,7 +211,7 @@ public class HdfsReader {
       Schema.Type fieldType = record.getSchema().getField(field).schema().getType();
       if (valueObject == null || fieldType == Schema.Type.NULL) {
         jsonObject.add(field, JsonNull.INSTANCE);
-      } else if (fieldType == Schema.Type.STRING) {
+      } else if (fieldType == Schema.Type.STRING || fieldType == Schema.Type.UNION) {
         jsonObject.addProperty(field, EncryptionUtils.decryptGobblin(valueObject.toString(), state));
       } else if (fieldType == Schema.Type.ARRAY) {
         jsonObject.add(field, gson.fromJson(valueObject.toString(), JsonArray.class));

--- a/cdi-core/src/main/java/com/linkedin/cdi/util/JsonElementTypes.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/util/JsonElementTypes.java
@@ -44,7 +44,7 @@ public enum JsonElementTypes {
   INTEGER("integer", "int"),
   INT64("int64", "long"),
   LONG("long"),
-  MAP("map", "map", false), // This is for nested json support
+  MAP("map", "map", false),
   NUMBER("number", "double"),
   OBJECT("object", "record", false),
   PRIMITIVE("primitive"),

--- a/cdi-core/src/main/java/com/linkedin/cdi/util/JsonElementTypes.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/util/JsonElementTypes.java
@@ -44,7 +44,7 @@ public enum JsonElementTypes {
   INTEGER("integer", "int"),
   INT64("int64", "long"),
   LONG("long"),
-  MAP("map", "map", false),
+  MAP("map", "map", false), // This is for nested json support
   NUMBER("number", "double"),
   OBJECT("object", "record", false),
   PRIMITIVE("primitive"),


### PR DESCRIPTION
Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [JIRA](https://jira01.corp.linkedin.com:8443/issues) issues and references them in the PR title. 

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

There's a new requirement of having support for decryption of secondary input values. One of the flows needs to be able to provide an encrypted token as a secondary input which can be used under ms.parameters. 
Without this change, the value under ms.parameter was not eligible to be decrypted even if it's of the form ENC(..)


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The flow that has this requirement, has been tested. Earlier it used to make the HTTP call with ENC(...) under the parameters. Now, it first decrypts and then makes the HTTP call. 


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

