### PR TITLE
prevent false failure if session state failCondition is undefined

### DIFF
--- a/cdi-core/src/main/java/com/linkedin/cdi/extractor/MultistageExtractor.java
+++ b/cdi-core/src/main/java/com/linkedin/cdi/extractor/MultistageExtractor.java
@@ -723,14 +723,14 @@ public class MultistageExtractor<S, D> implements Extractor<S, D> {
   }
 
   /**
-   * Check if session state is enabled and session fail condition is met
+   * Check if session state is enabled with a session fail condition defined, and the fail condition is met
    *
-   * @return true if session state is enabled and session fail condition is met
+   * @return true if session state is enabled with a session fail condition defined, and the fail condition is met
    * otherwise return false
    */
   protected boolean isSessionStateFailed() {
-    return jobKeys.isSessionStateEnabled() && extractorKeys.getSessionKeyValue()
-        .matches(jobKeys.getSessionStateFailCondition());
+    return jobKeys.isSessionStateEnabled() && StringUtils.isNotBlank(jobKeys.getSessionStateFailCondition())
+        && extractorKeys.getSessionKeyValue().matches(jobKeys.getSessionStateFailCondition());
   }
 
   /**


### PR DESCRIPTION
Dear DIL maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses a bug found during LinkedIn [APA-138105](https://linkedin.atlassian.net/browse/APA-138105)

### Description
- [x] Here are some details about my PR: When a session state value can be empty, I found that an explicit failure condition needed to be added to `ms.session.key.field` in order to prevent `isSessionStateFailed()` from unexpectedly returning true, due to the empty string matching the empty string. This allows the session to continue polling rather than ending after 1 attempt. This case can apply where the session key is the list filenames output (e.g. status check before 2-step file download pattern). 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: MultistageExtractor does not have unit tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

