### PR TITLE
Pin build-info-extractor-gradle to 5.2.5 to fix Gradle 6.8.1 build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:1.0.2'
     classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
     classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0"
-    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:latest.release'
+    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:5.2.5'
     classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     classpath "org.shipkit:shipkit-auto-version:latest.release"
     classpath "org.shipkit:shipkit-changelog:latest.release"


### PR DESCRIPTION
## Problem

`./gradlew build` fails on master at the project-configuration phase:

```
* What went wrong:
A problem occurred configuring root project 'data-integration-library'.
> Failed to create Jar file ~/.gradle/caches/jars-8/<hash>/jackson-core-2.15.4.jar.

Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 61
    at org.objectweb.asm.ClassReader.<init>(ClassReader.java:196)
    at org.gradle.internal.classpath.InstrumentingClasspathFileTransformer
```

This affects every PR, not a single branch — master itself reproduces it. CI was last green on 2025-06-06; the next CI run (on PR #93) failed with this error.

## Root cause

`build.gradle` pins three plugins to dynamic versions:

```gradle
classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:latest.release'
classpath "org.shipkit:shipkit-auto-version:latest.release"
classpath "org.shipkit:shipkit-changelog:latest.release"
```

Between June 2025 and now, JFrog published `build-info-extractor-gradle` 6.0.0+, which `latest.release` now resolves to (current: `6.0.4`). 6.0.0+ bumped its `jackson-databind` dependency from `2.14.1` → `2.15.4`, transitively pulling in `jackson-core:2.15.4` — a multi-release JAR containing Java 17 (`major version 61`) class files.

Gradle 6.8.1's classpath instrumenter walks every class in every buildscript jar (to cache an instrumented copy under `~/.gradle/caches/jars-8/`) using a bundled ASM that predates Java 17 bytecode support. It cannot read the MR-JAR Java 17 entries and aborts before the project ever compiles.

This was confirmed locally with JDK 8 + Gradle 6.8.1 (matching CI). Cache invalidation, daemon restart, and `--refresh-dependencies` all reproduce identically — it is a deterministic incompatibility, not a transient cache/network issue.

## Fix

Pin `build-info-extractor-gradle` to `5.2.5` — the last release on `jackson-databind:2.14.1`, which is Java 8 compatible and configures cleanly under Gradle 6.8.1.

The other two `latest.release` lines (shipkit-auto-version, shipkit-changelog) do not transitively depend on jackson and are not currently broken; they are left untouched in this minimal fix but remain a latent risk for future drift.

## Validation

Local build with the pin applied (JDK 1.8.0_282 + Gradle 6.8.1):

```
$ ./gradlew build
...
> Task :cdi-core:check
> Task :cdi-core:build
BUILD SUCCESSFUL in 50s
13 actionable tasks: 9 executed, 4 up-to-date
```

All existing tests pass.

## Back-compatibility

- No behavior change at runtime — this is a build-time plugin version pin only.
- Plugin 5.2.5 has been generally available since well before the last green CI run, so this rolls back to a known-good state rather than introducing new risk.