### PR TITLE
version bump 0.2.119

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.2.118
+version=0.2.119


### PR DESCRIPTION
## Summary

Bumps `version.properties` from `0.2.118` to `0.2.119` to cut a new release.

## Why this is needed

The `Release and Publish` workflow ran successfully on the merge of #93 (run [25154348045](https://github.com/linkedin/data-integration-library/actions/runs/25154348045), 2026-04-30) but produced no new GitHub release tag. Reason: `./gradlew getVersion` reads `version.properties`, which still held `0.2.118` — the version of the previous release on 2025-06-06. With no version change, `:githubRelease` had no new tag to create.

This matches the historical pattern in this repo:
- `13b301a` "version bump" → 0.2.116 → 0.2.117
- `8f3997b` "Nested Map JSON Schema Support" → 0.2.117 → 0.2.118 (bundled with feature)

## Changes covered by this release

- #93 — `ms.hdfs.reader.parse.json.strings` flag for inlining JSON strings in `HdfsReader`
- #94 — pin `build-info-extractor-gradle` to `5.2.5` to fix Gradle 6.8.1 buildscript-classpath instrumentation

## Test plan

- [x] `version.properties` updated to `0.2.119` (preserving the no-trailing-newline format used by prior version-bump commits)
- [ ] On merge, watch [Release and Publish workflow](https://github.com/linkedin/data-integration-library/actions/workflows/release.yml) — expect tag `v0.2.119` and a new entry in [Releases](https://github.com/linkedin/data-integration-library/releases)
- [ ] Confirm artifact `com.linkedin.cdi:cdi-core:0.2.119` lands in `https://linkedin.jfrog.io/artifactory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)